### PR TITLE
small fixes, comments, and script tweak

### DIFF
--- a/animated-transformer/src/lib/logic/rules.spec.ts
+++ b/animated-transformer/src/lib/logic/rules.spec.ts
@@ -41,7 +41,7 @@ describe('rules', () => {
       op,
       score,
       posConditions: conditions,
-    } = parseRule('S(squishes _x _y | jumps-over _x:monkey _y:flower) += 1');
+    } = parseRule('S(squishes _x _y | jumpsOver _x:monkey _y:flower) += 1');
     expect(rel.relName).toEqual('squishes');
     expect(rel.args[0].varName).toEqual('_x');
     expect(rel.args[0].varTypes).toEqual(new Set(universalType));
@@ -50,7 +50,7 @@ describe('rules', () => {
     expect(op).toEqual('+=');
     expect(score).toEqual(1.0);
     expect(conditions.length).toEqual(1);
-    expect(conditions[0].relName).toEqual('jumps-over');
+    expect(conditions[0].relName).toEqual('jumpsOver');
     expect(conditions[0].args[0]).toEqual({ varName: '_x', varTypes: new Set(['monkey']) });
     expect(conditions[0].args[1]).toEqual({ varName: '_y', varTypes: new Set(['flower']) });
   });
@@ -61,7 +61,7 @@ describe('rules', () => {
       op,
       score,
       posConditions: conditions,
-    } = parseRule('S(squishes ?x ?y | jumps-over ?x ?y) += 1');
+    } = parseRule('S(squishes ?x ?y | jumpsOver ?x ?y) += 1');
     expect(rel.relName).toEqual('squishes');
     expect(rel.args[0].varName).toEqual('?x');
     expect(rel.args[0].varTypes).toEqual(new Set(universalType));
@@ -70,7 +70,7 @@ describe('rules', () => {
     expect(op).toEqual('+=');
     expect(score).toEqual(1.0);
     expect(conditions.length).toEqual(1);
-    expect(conditions[0].relName).toEqual('jumps-over');
+    expect(conditions[0].relName).toEqual('jumpsOver');
     expect(conditions[0].args[0]).toEqual({ varName: '?x', varTypes: new Set(universalType) });
     expect(conditions[0].args[1]).toEqual({ varName: '?y', varTypes: new Set(universalType) });
   });
@@ -84,7 +84,7 @@ describe('rules', () => {
       posConditions: conditions,
     } = parseRule(`
     S(squishes _x _y 
-    | jumps-over _x _y, jumps-over _x _y, jumps-over _x _y) *= 0
+    | jumpsOver _x _y, jumpsOver _x _y, jumpsOver _x _y) *= 0
     `);
     expect(rel.relName).toEqual('squishes');
     expect(rel.args[0]).toEqual({ varName: '_x', varTypes: new Set(universalType) });
@@ -92,13 +92,13 @@ describe('rules', () => {
     expect(op).toEqual('*=');
     expect(score).toEqual(0);
     expect(conditions.length).toEqual(3);
-    expect(conditions[0].relName).toEqual('jumps-over');
+    expect(conditions[0].relName).toEqual('jumpsOver');
     expect(conditions[0].args[0]).toEqual({ varName: '_x', varTypes: new Set(['*']) });
     expect(conditions[0].args[1]).toEqual({ varName: '_y', varTypes: new Set(['*']) });
-    expect(conditions[1].relName).toEqual('jumps-over');
+    expect(conditions[1].relName).toEqual('jumpsOver');
     expect(conditions[1].args[0]).toEqual({ varName: '_x', varTypes: new Set(['*']) });
     expect(conditions[1].args[1]).toEqual({ varName: '_y', varTypes: new Set(['*']) });
-    expect(conditions[2].relName).toEqual('jumps-over');
+    expect(conditions[2].relName).toEqual('jumpsOver');
     expect(conditions[2].args[0]).toEqual({ varName: '_x', varTypes: new Set(['*']) });
     expect(conditions[2].args[1]).toEqual({ varName: '_y', varTypes: new Set(['*']) });
   });
@@ -107,7 +107,7 @@ describe('rules', () => {
   it('parseRule: 3 conditions and one neg', () => {
     const { rel, op, score, posConditions, negConditions } = parseRule(`
     S(squishes _x _y 
-    | jumps-over _x _y, jumps-over _x _y, -is _y, jumps-over _x _y) *= 0
+    | jumpsOver _x _y, jumpsOver _x _y, -is _y, jumpsOver _x _y) *= 0
     `);
     expect(rel.relName).toEqual('squishes');
     expect(rel.args[0]).toEqual({ varName: '_x', varTypes: new Set(['*']) });
@@ -115,13 +115,13 @@ describe('rules', () => {
     expect(op).toEqual('*=');
     expect(score).toEqual(0);
     expect(posConditions.length).toEqual(3);
-    expect(posConditions[0].relName).toEqual('jumps-over');
+    expect(posConditions[0].relName).toEqual('jumpsOver');
     expect(posConditions[0].args[0]).toEqual({ varName: '_x', varTypes: new Set(['*']) });
     expect(posConditions[0].args[1]).toEqual({ varName: '_y', varTypes: new Set(['*']) });
-    expect(posConditions[1].relName).toEqual('jumps-over');
+    expect(posConditions[1].relName).toEqual('jumpsOver');
     expect(posConditions[1].args[0]).toEqual({ varName: '_x', varTypes: new Set(['*']) });
     expect(posConditions[1].args[1]).toEqual({ varName: '_y', varTypes: new Set(['*']) });
-    expect(posConditions[2].relName).toEqual('jumps-over');
+    expect(posConditions[2].relName).toEqual('jumpsOver');
     expect(posConditions[2].args[0]).toEqual({ varName: '_x', varTypes: new Set(['*']) });
     expect(posConditions[2].args[1]).toEqual({ varName: '_y', varTypes: new Set(['*']) });
     expect(negConditions.length).toEqual(1);
@@ -131,7 +131,7 @@ describe('rules', () => {
 
   // TODO: maybe no varType can mean any time, and we can skip the explicit type of all types?
   it('print and parseRule symmetry', () => {
-    const initRuleStr = `S(squishes _x _y | jumps-over _x _y, jumps-over _x _y, jumps-over _x _y) *= 0`;
+    const initRuleStr = `S(squishes _x _y | jumpsOver _x _y, jumpsOver _x _y, jumpsOver _x _y) *= 0`;
     const rule = parseRule(initRuleStr);
     const parsedRuleStr = stringifyRule(rule);
     expect(parsedRuleStr).toEqual(initRuleStr);

--- a/animated-transformer/src/lib/tokens/token_gemb.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.ts
@@ -232,6 +232,18 @@ export function strSeqPrepFnAddingFinalMask<
 
 // TODO: maybe change the type to somethinfg more specific and without tokenEmb
 // and maxInputLength since they are not relevant.
+//
+// Note: outputSeqs is a list of next tokens, where each inner list contains an
+// entry for each example in the batch.
+// e.g.
+// if you have batch size 3, and 3 continuations:
+//    example 1 continuation: cat
+//    example 2 continuation: boo
+//    example 3 continuation: foo
+// Then you have an outputSeqs array: [[c,b,f], [a,o,o], [t,o,o]]
+// And this function returns the token indexes for [c,b,f].
+//
+// TODO: we'll want to generalise this for longer sequences...
 export function singleNextTokenIdxOutputPrepFn(
   tokenRep: BasicTaskTokenRep,
   outputSeqs: string[][]


### PR DESCRIPTION
* Makes the token output probabilities in the script get sorted nicely. 
* Fix updated examples in rules.spec file
* Adds a couple of comments. 

Playing around with some hyper-params for tiny transformers, I think my layer-norm implementation might be broken; without it turned off the transformer learns as expected (result below), but with layer norm enabled, the model only learns very general stats. 

Example successful run: 
`$ npx ts-node src/lib/seqtasks/tiny_worlds.run_with_transformer.script.ts`

Final part of the output
```
batch: 290     entropyLoss: 1.05391383  accuracy: 0.53125000
(0) is _a:monkey, is _b: ---> cat, is _c
Inference Step: 0
Context: is _a:monkey, is _b:
Target Output: cat
Target next token: cat
Prediction:
    token        prob
    flower       0.27120873
    cat          0.24495488    <- Target
    monkey       0.19198164
    rock         0.12438986
    tree         0.08662897
    elephant     0.07370050
    :            0.00210857
    ,            0.00078981
    _a           0.00078500
```