### PR TITLE
Laubrito masked self attention and decoder loss over all tokens at once

### DIFF
--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -56,7 +56,7 @@ describe('gtensor', () => {
           [5, 6],
         ], // example index 3
       ]),
-      ['example', 'pos', 'repSize']
+      ['example', 'pos', 'repSize'],
     );
     expect(g2.gshape()).toEqual({ example: 4, pos: 3, repSize: 2 });
   });
@@ -89,7 +89,7 @@ describe('gtensor', () => {
           [5, 6],
         ],
       ]),
-      ['example', 'pos', 'repSize']
+      ['example', 'pos', 'repSize'],
     );
     expect(g1.gshape()).toEqual({ example: 4, pos: 3, repSize: 2 });
     const g2 = g1.transpose();
@@ -123,9 +123,9 @@ describe('gtensor', () => {
             [3, 4],
             [5, 6],
           ],
-        ] // example = 4
+        ], // example = 4
       ),
-      ['example', 'pos', 'repSize']
+      ['example', 'pos', 'repSize'],
     );
 
     const g2 = new gtensor.GTensor(
@@ -149,9 +149,9 @@ describe('gtensor', () => {
             [5, 6],
             [5, 6],
           ],
-        ] // pos = 3
+        ], // pos = 3
       ),
-      ['pos', 'example', 'repSize']
+      ['pos', 'example', 'repSize'],
     );
     expect(g1.gshape()).toEqual({ pos: 3, example: 4, repSize: 2 });
     const likeg2 = g1.transposeLike(g2);
@@ -168,14 +168,14 @@ describe('gtensor', () => {
         [3, 4, 5],
         [5, 6, 7],
       ]),
-      ['pos', 'repSize']
+      ['pos', 'repSize'],
     );
 
     const g2 = new gtensor.GTensor(
       tf.tensor(
-        [1, 2, 3] // pos = 3
+        [1, 2, 3], // pos = 3
       ),
-      ['pos']
+      ['pos'],
     );
     const g2big = g2.broadcastToCombinedShape(g1);
 
@@ -202,9 +202,9 @@ describe('gtensor', () => {
             [3, 4],
             [5, 6],
           ],
-        ] // example = 2
+        ], // example = 2
       ),
-      ['example', 'pos', 'repSize']
+      ['example', 'pos', 'repSize'],
     );
 
     const g2 = new gtensor.GTensor(
@@ -222,9 +222,9 @@ describe('gtensor', () => {
             [5, 6],
             [5, 6],
           ],
-        ] // pos = 3
+        ], // pos = 3
       ),
-      ['pos', 'foo', 'repSize']
+      ['pos', 'foo', 'repSize'],
     );
     expect(g2.gshape()).toEqual({ pos: 3, foo: 2, repSize: 2 });
     const g1big = g1.broadcastToCombinedShape(g2);
@@ -249,9 +249,9 @@ describe('gtensor', () => {
             [3, 4],
             [5, 6],
           ],
-        ] // example = 2
+        ], // example = 2
       ),
-      ['example', 'pos', 'repSize']
+      ['example', 'pos', 'repSize'],
     );
 
     const g1big = g1.broadcastTo(new Map([['foo', 2]]));
@@ -266,9 +266,9 @@ describe('gtensor', () => {
     const bar = new gtensor.GTensor(
       tf.initializers.truncatedNormal({}).apply(
         // Dimension sizes. Notice: c = 3.
-        [1, 2, 3, 4, 5]
+        [1, 2, 3, 4, 5],
       ),
-      ['a', 'b', 'c', 'd', 'e']
+      ['a', 'b', 'c', 'd', 'e'],
     );
     const foo = gtensor.makeZeros({ x: 6, y: 2, c: 3 });
 
@@ -293,7 +293,7 @@ describe('gtensor', () => {
         [1, 2],
         [3, 4],
       ]),
-      ['example', 'repSize']
+      ['example', 'repSize'],
     );
     const foo = new gtensor.GTensor(
       tf.tensor([
@@ -301,7 +301,7 @@ describe('gtensor', () => {
         [3, 4],
         [5, 6],
       ]),
-      ['point_id', 'repSize']
+      ['point_id', 'repSize'],
     );
     const r = bar.pointwiseAdd(foo);
     expect(r.gshape()).toEqual({ example: 2, point_id: 3, repSize: 2 });
@@ -329,7 +329,7 @@ describe('gtensor', () => {
           [3, 4],
         ],
       ]),
-      ['batch', 'example', 'repSize']
+      ['batch', 'example', 'repSize'],
     );
     const foo = new gtensor.GTensor(
       tf.tensor([
@@ -337,7 +337,7 @@ describe('gtensor', () => {
         [3, 4],
         [5, 6],
       ]),
-      ['point_id', 'repSize']
+      ['point_id', 'repSize'],
     );
     const r = bar.pointwiseAdd(foo);
     expect(r.gshape()).toEqual({
@@ -370,7 +370,7 @@ describe('gtensor', () => {
         [2, 3, 4],
         [4, 5, 6],
       ]),
-      ['pos', 'repSize']
+      ['pos', 'repSize'],
     );
     const foo = new gtensor.GTensor(tf.tensor([1, 2, 3]), ['pos']);
     const s1 = bar.pointwiseAdd(foo);
@@ -396,7 +396,7 @@ describe('gtensor', () => {
         [1, 2],
         [3, 4],
       ]),
-      ['example', 'repSize']
+      ['example', 'repSize'],
     );
     const foo = new gtensor.GTensor(
       tf.tensor([
@@ -404,7 +404,7 @@ describe('gtensor', () => {
         [3, 4, 5],
         [5, 6, 7],
       ]),
-      ['point_id', 'repSize2']
+      ['point_id', 'repSize2'],
     );
     const r = bar.pointwiseAdd(foo);
     // console.log(r.tensor);
@@ -445,7 +445,7 @@ describe('gtensor', () => {
         [1, 2],
         [3, 4],
       ]),
-      ['example', 'repSize']
+      ['example', 'repSize'],
     );
     const foo = new gtensor.GTensor(
       tf.tensor([
@@ -453,7 +453,7 @@ describe('gtensor', () => {
         [3, 4],
         [5, 6],
       ]),
-      ['point_id', 'repSize']
+      ['point_id', 'repSize'],
     );
     const r = bar.pointwiseMul(foo);
     expect(r.gshape()).toEqual({ example: 2, point_id: 3, repSize: 2 });
@@ -485,7 +485,7 @@ describe('gtensor', () => {
           [1, 1],
         ],
       ]),
-      ['a', 'b', 'c']
+      ['a', 'b', 'c'],
     );
     const t2 = t.mergeDims(['a', 'b'], 'ab');
     expect(t2.gshape()).toEqual({ ab: 4, c: 2 });
@@ -521,7 +521,7 @@ describe('gtensor', () => {
         [1, 0, 0],
         [1, 1, 0],
       ]),
-      ['example', 'rep']
+      ['example', 'rep'],
     );
     const t2 = t.splitDim('example', { x: 2, y: 2 });
     expect(t2.gshape()).toEqual({ x: 2, y: 2, rep: 3 });
@@ -549,7 +549,7 @@ describe('gtensor', () => {
           [1, 1],
         ],
       ]),
-      ['a', 'b', 'c']
+      ['a', 'b', 'c'],
     );
 
     const rSumA = t.prodOverDims(['a']);
@@ -590,7 +590,7 @@ describe('gtensor', () => {
           [1, 1],
         ],
       ]),
-      ['a', 'b', 'c']
+      ['a', 'b', 'c'],
     );
 
     const rSumA = t.sumOverDims(['a']);
@@ -626,7 +626,7 @@ describe('gtensor', () => {
         [2, 1],
         [3, 1],
       ]),
-      ['point_id', 'inputRepSize']
+      ['point_id', 'inputRepSize'],
     );
     const g2 = GTensor.fromSerialised(g.toSerialised());
     expect(g.tensor.arraySync()).toEqual(g2.tensor.arraySync());
@@ -639,7 +639,7 @@ describe('gtensor', () => {
         [0, 1],
         [1, 1],
       ]),
-      ['point_id', 'inputRepSize']
+      ['point_id', 'inputRepSize'],
     );
 
     const r = paramPositions.squaredDifference(paramPositions.rename('point_id', 'point_id2'));
@@ -671,7 +671,7 @@ describe('gtensor', () => {
         [1, 2, 3, 4],
         [5, 6, 7, 8],
       ]),
-      ['heads', 'relativePos']
+      ['heads', 'relativePos'],
     );
 
     const indexes = new gtensor.GTensor(
@@ -682,9 +682,9 @@ describe('gtensor', () => {
           [2, 3],
         ],
         [3, 2],
-        'int32'
+        'int32',
       ),
-      ['keyPos', 'queryPos']
+      ['keyPos', 'queryPos'],
     );
 
     const gathered = g.gather(indexes, 'relativePos');
@@ -704,7 +704,7 @@ describe('gtensor', () => {
             [7, 8],
           ],
         ])
-        .dataSync()
+        .dataSync(),
     );
   });
 
@@ -741,7 +741,7 @@ describe('gtensor', () => {
           [6, 7.3],
         ], // example index 1
       ]),
-      ['batch', 'pos', 'repSize']
+      ['batch', 'pos', 'repSize'],
     );
 
     tf.test_util.expectArraysClose(
@@ -759,7 +759,7 @@ describe('gtensor', () => {
             tf.softmax([6, 7.3]).dataSync(),
           ],
         ])
-        .dataSync()
+        .dataSync(),
     );
 
     const gsoftmax = g.softmax('pos');
@@ -781,11 +781,11 @@ describe('gtensor', () => {
           [batch1pos0rep[2], batch1pos1rep[2]],
         ],
       ]),
-      ['batch', 'pos', 'repSize']
+      ['batch', 'pos', 'repSize'],
     );
     tf.test_util.expectArraysClose(
       gsoftmax.tensor.dataSync(),
-      expectedGTensor.transposeLike(gsoftmax).tensor.dataSync()
+      expectedGTensor.transposeLike(gsoftmax).tensor.dataSync(),
     );
   });
 
@@ -809,7 +809,7 @@ describe('gtensor', () => {
           [6, 7],
         ], // example index 1
       ]),
-      ['example', 'pos', 'repSize']
+      ['example', 'pos', 'repSize'],
     );
 
     const gs = g.unstack('pos');
@@ -829,7 +829,7 @@ describe('gtensor', () => {
     });
 
     function attentionHeadFn(
-      input: GTensor<'seqLen' | 'inputRep'>
+      input: GTensor<'seqLen' | 'inputRep'>,
     ): GTensor<'seqLen' | 'valueRep'> {
       const inputKeys = input.contract(keyM, ['inputRep']).rename('seqLen', 'keySeqLen');
       const inputQueries = input.contract(queryM, ['inputRep']);
@@ -871,15 +871,13 @@ describe('gtensor', () => {
       _Error_GivenHadExtraTypes: ['Error_GivenHadExtraTypes', T];
     }
 
-    type ExactGTensor<Exact extends string, Given extends string> = Exclude<
-      Given,
-      Exact
-    > extends never
-      ? GTensor<Given>
-      : ErrorGivenHadExtraTypes<Exclude<Given, Exact>>;
+    type ExactGTensor<Exact extends string, Given extends string> =
+      Exclude<Given, Exact> extends never
+        ? GTensor<Given>
+        : ErrorGivenHadExtraTypes<Exclude<Given, Exact>>;
 
     function attentionHeadFn2<T extends string>(
-      maybeInput: ExactGTensor<'seqLen' | 'inputRep', T>
+      maybeInput: ExactGTensor<'seqLen' | 'inputRep', T>,
     ): GTensor<'seqLen' | 'valueRep'> {
       const input = maybeInput as never as GTensor<'seqLen' | 'inputRep'>;
       const inputKeys = input.contract(keyM, ['inputRep']).rename('seqLen', 'keySeqLen');
@@ -899,63 +897,92 @@ describe('gtensor', () => {
 
   it('simple Lower triangular -Inf mask', async () => {
     const g1 = new gtensor.GTensor(
-      tf.tensor([[[
-        [1, 2, 3],
-        [3, 4, 5],
-        [5, 6, 7]]
-      ]]),
-      ['heads', 'batch', 'Pos1', 'Pos2']
+      tf.tensor([
+        [
+          [
+            [1, 2, 3],
+            [3, 4, 5],
+            [5, 6, 7],
+          ],
+        ],
+      ]),
+      ['heads', 'batch', 'Pos1', 'Pos2'],
     );
     const g1tril = g1.TriangularMask(['batch', 'Pos1', 'Pos2'], -Infinity, 0);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
-    tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(),
-      [[[[0, -Infinity, -Infinity],
-      [0, 0, -Infinity],
-      [0, 0, 0]]
-    ]]);
+    tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
+      [
+        [
+          [0, -Infinity, -Infinity],
+          [0, 0, -Infinity],
+          [0, 0, 0],
+        ],
+      ],
+    ]);
   });
 
   it('Multiple heads Lower triangular -Inf mask', async () => {
     const g1 = new gtensor.GTensor(
       tf.tensor([
         [
-        [[1, 2, 3],
-        [3, 4, 5],
-        [5, 6, 7]],
-        [[8, 9, 10],
-      [11, 12, 13],
-      [14, 15, 16]]
-    ],
-    [
-      [[1, 2, 3],
-      [3, 4, 5],
-      [5, 6, 7]],
-      [[8, 9, 10],
-    [11, 12, 13],
-    [14, 15, 16]]
-  ]]),
-      ['heads', 'batch', 'Pos1', 'Pos2']
+          [
+            [1, 2, 3],
+            [3, 4, 5],
+            [5, 6, 7],
+          ],
+          [
+            [8, 9, 10],
+            [11, 12, 13],
+            [14, 15, 16],
+          ],
+        ],
+        [
+          [
+            [1, 2, 3],
+            [3, 4, 5],
+            [5, 6, 7],
+          ],
+          [
+            [8, 9, 10],
+            [11, 12, 13],
+            [14, 15, 16],
+          ],
+        ],
+      ]),
+      ['heads', 'batch', 'Pos1', 'Pos2'],
     );
     const g1tril = g1.TriangularMask(['batch', 'Pos1', 'Pos2'], 42, 1);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
-    tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(),
-    [[[[1 , 42, 42],
-    [1 , 1        , 42],
-    [1 , 1        , 1        ]],
+    tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
+      [
+        [
+          [1, 42, 42],
+          [1, 1, 42],
+          [1, 1, 1],
+        ],
 
-   [[1 , 42, 42],
-   [1 , 1        , 42],
-   [1 , 1        , 1        ]]],
+        [
+          [1, 42, 42],
+          [1, 1, 42],
+          [1, 1, 1],
+        ],
+      ],
 
+      [
+        [
+          [1, 42, 42],
+          [1, 1, 42],
+          [1, 1, 1],
+        ],
 
-  [[[1 , 42, 42],
-  [1 , 1        , 42],
-  [1 , 1        , 1        ]],
-
-   [[1 , 42, 42],
-   [1 , 1        , 42],
-   [1 , 1        , 1        ]]]]);
+        [
+          [1, 42, 42],
+          [1, 1, 42],
+          [1, 1, 1],
+        ],
+      ],
+    ]);
   });
 });

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -895,7 +895,7 @@ describe('gtensor', () => {
     const attendedValues3 = attentionHeadFn2(oneInput);
   });
 
-  it('simple Lower triangular -Inf mask', async () => {
+  it('simple triangular mask', async () => {
     const g1 = new gtensor.GTensor(
       tf.tensor([
         [
@@ -908,15 +908,15 @@ describe('gtensor', () => {
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.triangularMask('Pos1', 'Pos2', -Infinity);
+    const g1tril = g1.triangularMask('Pos1', 'Pos2', 42);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
       [
         [
-          [0, -Infinity, -Infinity],
-          [3, 4, -Infinity],
-          [6, 7, 8],
+          [0, 42, 42],
+          [0, 0, 42],
+          [0, 0, 0],
         ],
       ],
     ]);
@@ -952,34 +952,34 @@ describe('gtensor', () => {
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.triangularMask('Pos1', 'Pos2', 42);
+    const g1tril = g1.pointwiseAdd(g1.triangularMask('Pos1', 'Pos2', -Infinity));
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
       [
         [
-          [0, 42, 42],
-          [3, 4, 42],
+          [0, -Infinity, -Infinity],
+          [3, 4, -Infinity],
           [6, 7, 8],
         ],
 
         [
-          [9, 42, 42],
-          [12, 13, 42],
+          [9, -Infinity, -Infinity],
+          [12, 13, -Infinity],
           [15, 16, 17],
         ],
       ],
 
       [
         [
-          [0, 42, 42],
-          [3, 4, 42],
+          [0, -Infinity, -Infinity],
+          [3, 4, -Infinity],
           [6, 7, 8],
         ],
 
         [
-          [9, 42, 42],
-          [12, 13, 42],
+          [9, -Infinity, -Infinity],
+          [12, 13, -Infinity],
           [15, 16, 17],
         ],
       ],

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -896,4 +896,66 @@ describe('gtensor', () => {
     // const attendedValues2 = attentionHeadFn2(batchedInput); // Has error, yay, but what a mess...
     const attendedValues3 = attentionHeadFn2(oneInput);
   });
+
+  it('simple Lower triangular -Inf mask', async () => {
+    const g1 = new gtensor.GTensor(
+      tf.tensor([[[
+        [1, 2, 3],
+        [3, 4, 5],
+        [5, 6, 7]]
+      ]]),
+      ['heads', 'batch', 'Pos1', 'Pos2']
+    );
+    const g1tril = g1.TriangularMask(['batch', 'Pos1', 'Pos2'], -Infinity, 0);
+
+    expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
+    tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(),
+      [[[[0, -Infinity, -Infinity],
+      [0, 0, -Infinity],
+      [0, 0, 0]]
+    ]]);
+  });
+
+  it('Multiple heads Lower triangular -Inf mask', async () => {
+    const g1 = new gtensor.GTensor(
+      tf.tensor([
+        [
+        [[1, 2, 3],
+        [3, 4, 5],
+        [5, 6, 7]],
+        [[8, 9, 10],
+      [11, 12, 13],
+      [14, 15, 16]]
+    ],
+    [
+      [[1, 2, 3],
+      [3, 4, 5],
+      [5, 6, 7]],
+      [[8, 9, 10],
+    [11, 12, 13],
+    [14, 15, 16]]
+  ]]),
+      ['heads', 'batch', 'Pos1', 'Pos2']
+    );
+    const g1tril = g1.TriangularMask(['batch', 'Pos1', 'Pos2'], 42, 1);
+
+    expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
+    tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(),
+    [[[[1 , 42, 42],
+    [1 , 1        , 42],
+    [1 , 1        , 1        ]],
+
+   [[1 , 42, 42],
+   [1 , 1        , 42],
+   [1 , 1        , 1        ]]],
+
+
+  [[[1 , 42, 42],
+  [1 , 1        , 42],
+  [1 , 1        , 1        ]],
+
+   [[1 , 42, 42],
+   [1 , 1        , 42],
+   [1 , 1        , 1        ]]]]);
+  });
 });

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -900,23 +900,23 @@ describe('gtensor', () => {
       tf.tensor([
         [
           [
-            [1, 2, 3],
+            [0, 1, 2],
             [3, 4, 5],
-            [5, 6, 7],
+            [6, 7, 8],
           ],
         ],
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.triangularMask('Pos1', 'Pos2', -Infinity, 0);
+    const g1tril = g1.triangularMask('Pos1', 'Pos2', -Infinity);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
       [
         [
           [0, -Infinity, -Infinity],
-          [0, 0, -Infinity],
-          [0, 0, 0],
+          [3, 4, -Infinity],
+          [6, 7, 8],
         ],
       ],
     ]);
@@ -927,60 +927,60 @@ describe('gtensor', () => {
       tf.tensor([
         [
           [
-            [1, 2, 3],
+            [0, 1, 2],
             [3, 4, 5],
-            [5, 6, 7],
+            [6, 7, 8],
           ],
           [
-            [8, 9, 10],
-            [11, 12, 13],
-            [14, 15, 16],
+            [9, 10, 11],
+            [12, 13, 14],
+            [15, 16, 17],
           ],
         ],
         [
           [
-            [1, 2, 3],
+            [0, 1, 2],
             [3, 4, 5],
-            [5, 6, 7],
+            [6, 7, 8],
           ],
           [
-            [8, 9, 10],
-            [11, 12, 13],
-            [14, 15, 16],
+            [9, 10, 11],
+            [12, 13, 14],
+            [15, 16, 17],
           ],
         ],
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.triangularMask('Pos1', 'Pos2', 42, 1);
+    const g1tril = g1.triangularMask('Pos1', 'Pos2', 42);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
       [
         [
-          [1, 42, 42],
-          [1, 1, 42],
-          [1, 1, 1],
+          [0, 42, 42],
+          [3, 4, 42],
+          [6, 7, 8],
         ],
 
         [
-          [1, 42, 42],
-          [1, 1, 42],
-          [1, 1, 1],
+          [9, 42, 42],
+          [12, 13, 42],
+          [15, 16, 17],
         ],
       ],
 
       [
         [
-          [1, 42, 42],
-          [1, 1, 42],
-          [1, 1, 1],
+          [0, 42, 42],
+          [3, 4, 42],
+          [6, 7, 8],
         ],
 
         [
-          [1, 42, 42],
-          [1, 1, 42],
-          [1, 1, 1],
+          [9, 42, 42],
+          [12, 13, 42],
+          [15, 16, 17],
         ],
       ],
     ]);

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -896,22 +896,8 @@ describe('gtensor', () => {
   });
 
   it('simple triangular matrix', async () => {
-    const g1 = new gtensor.GTensor(
-      tf.tensor([
-        [
-          [
-            [0, 1, 2],
-            [3, 4, 5],
-            [6, 7, 8],
-          ],
-        ],
-      ]),
-      ['heads', 'batch', 'Pos1', 'Pos2'],
-    );
-    const g1tril = gtensor.makeTriangularMatrix(g1.dim['Pos1'].size, ['Pos1', 'Pos2'], 0, 42);
-    //const g1tril = g1.triangularMask('Pos1', 'Pos2', 42);
-
-    //expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
+    const size = 3;
+    const g1tril = gtensor.makeTriangularMatrix(size, 'Pos1', 'Pos2', 0, 42);
     expect(g1tril.dimNames).toEqual(['Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
       [0, 42, 42],

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -895,7 +895,7 @@ describe('gtensor', () => {
     const attendedValues3 = attentionHeadFn2(oneInput);
   });
 
-  it('simple triangular mask', async () => {
+  it('simple triangular matrix', async () => {
     const g1 = new gtensor.GTensor(
       tf.tensor([
         [
@@ -908,81 +908,15 @@ describe('gtensor', () => {
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.triangularMask('Pos1', 'Pos2', 42);
+    const g1tril = gtensor.makeTriangularMatrix(g1.dim['Pos1'].size, ['Pos1', 'Pos2'], 0, 42);
+    //const g1tril = g1.triangularMask('Pos1', 'Pos2', 42);
 
-    expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
+    //expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
+    expect(g1tril.dimNames).toEqual(['Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
-      [
-        [
-          [0, 42, 42],
-          [0, 0, 42],
-          [0, 0, 0],
-        ],
-      ],
-    ]);
-  });
-
-  it('Multiple heads Lower triangular -Inf mask', async () => {
-    const g1 = new gtensor.GTensor(
-      tf.tensor([
-        [
-          [
-            [0, 1, 2],
-            [3, 4, 5],
-            [6, 7, 8],
-          ],
-          [
-            [9, 10, 11],
-            [12, 13, 14],
-            [15, 16, 17],
-          ],
-        ],
-        [
-          [
-            [0, 1, 2],
-            [3, 4, 5],
-            [6, 7, 8],
-          ],
-          [
-            [9, 10, 11],
-            [12, 13, 14],
-            [15, 16, 17],
-          ],
-        ],
-      ]),
-      ['heads', 'batch', 'Pos1', 'Pos2'],
-    );
-    const g1tril = g1.pointwiseAdd(g1.triangularMask('Pos1', 'Pos2', -Infinity));
-
-    expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
-    tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
-      [
-        [
-          [0, -Infinity, -Infinity],
-          [3, 4, -Infinity],
-          [6, 7, 8],
-        ],
-
-        [
-          [9, -Infinity, -Infinity],
-          [12, 13, -Infinity],
-          [15, 16, 17],
-        ],
-      ],
-
-      [
-        [
-          [0, -Infinity, -Infinity],
-          [3, 4, -Infinity],
-          [6, 7, 8],
-        ],
-
-        [
-          [9, -Infinity, -Infinity],
-          [12, 13, -Infinity],
-          [15, 16, 17],
-        ],
-      ],
+      [0, 42, 42],
+      [0, 0, 42],
+      [0, 0, 0],
     ]);
   });
 });

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -854,7 +854,7 @@ describe('gtensor', () => {
     });
   });
 
-  xit('attentionHead2', () => {
+  it('attentionHead2', () => {
     const queryM = gtensor.makeTruncNormal({ inputRep: 2, kqRep: 3 });
     const keyM = gtensor.makeTruncNormal({ inputRep: 2, kqRep: 3 });
     const valueM = gtensor.makeTruncNormal({ inputRep: 2, valueRep: 4 });
@@ -908,7 +908,7 @@ describe('gtensor', () => {
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.TriangularMask('Pos1', 'Pos2', -Infinity, 0);
+    const g1tril = g1.triangularMask('Pos1', 'Pos2', -Infinity, 0);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
@@ -952,7 +952,7 @@ describe('gtensor', () => {
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.TriangularMask('Pos1', 'Pos2', 42, 1);
+    const g1tril = g1.triangularMask('Pos1', 'Pos2', 42, 1);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -908,7 +908,7 @@ describe('gtensor', () => {
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.TriangularMask(['batch', 'Pos1', 'Pos2'], -Infinity, 0);
+    const g1tril = g1.TriangularMask('Pos1', 'Pos2', -Infinity, 0);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [
@@ -952,7 +952,7 @@ describe('gtensor', () => {
       ]),
       ['heads', 'batch', 'Pos1', 'Pos2'],
     );
-    const g1tril = g1.TriangularMask(['batch', 'Pos1', 'Pos2'], 42, 1);
+    const g1tril = g1.TriangularMask('Pos1', 'Pos2', 42, 1);
 
     expect(g1tril.dimNames).toEqual(['heads', 'batch', 'Pos1', 'Pos2']);
     tf.test_util.expectArraysEqual(g1tril.tensor.arraySync(), [

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -834,44 +834,41 @@ export class GTensor<G extends DName> {
     return new GTensor<Exclude<G, D> | G2>(gathered, newDimNames);
   }
 
-  public triangularMask(dim1 : G, dim2: G, upper_triangle_const : number = 1, lower_triangle_const: number = 0): GTensor<G> {
-  /* Returns a triangular mask of the same shape as the provided GTensor
-  with upper tril values set 'upper_triangle_const' (default = 1)
-  and lower tril values set to 'lower_triangle_const' (default = 0)
+  public triangularMask(dim1 : G, dim2: G, upperTriangleConst: number): GTensor<G> {
+  /* Applies a triangular mask to the provided GTensor
+  the values of the upper triangle are set 'upper_triangle_const'
 
   Parameters:
   - dim1: First dimension of the triangular mask matrix (Should exist in the GTensor)
   - dim2: First dimension of the triangular mask matrix (Should exist in the GTensor)
-  - upper_triangle_const = constant to fill the upper triangle of the matrix, default = 1
-  - lower_triangle_const = constant to fill the lower triangle of the matrix, default = 0
+  - upper_triangle_const = constant to fill the upper triangle of the matrix
 
   Note: Tensor will be broadcasted over additional dimension i.e. heads, batch.
   */
 
-    let Pos_2 = this.dim[dim1].size
-    let Pos = this.dim[dim2].size
+    let size = this.dim[dim1].size
+    let size2 = this.dim[dim2].size
 
-    if (Pos !== Pos_2){
+    if (size !== size2){
       throw new Error(
         `Can't generate lower triangular mask for non square tensor `
       );
     }
 
-    // Make 2D tensor with 'upper_triangle_const' in the Upper triangle
-    let triu_aux = tf.fill([Pos+1, Pos], upper_triangle_const) // Make non square constant matrix of shape [Pos+1, Pos]
-    triu_aux = tf.linalg.bandPart(triu_aux, 0, -1) // Replace all the values under the main diagonal by 0
-    triu_aux = tf.slice(triu_aux, [1, 0], [Pos, Pos]) // Remove first row to obtain square matrix with tril = 0 and triu = 'upper_triangle_const'
-    // Make 2D Tensor with Ones in the Lower triangle
-    let tril_aux = tf.fill([Pos, Pos], lower_triangle_const)
-    tril_aux = tf.linalg.bandPart(tril_aux, 0, -1)
-    tril_aux = tril_aux.transpose() // I can directly transpose as I need the non zero values in the lower triangle to include the main diagonal
-    let tril_mask = tril_aux.add(triu_aux)
-
-    // Broadcast over batch and heads Dimension
-    let gtril_mask_broadcasted = new GTensor(tril_mask, [dim1, dim2]).broadcastToCombinedShape(this)
-    return gtril_mask_broadcasted;
+    // Create a range tensor for row indices
+    const rowIndices = tf.range(0, size, 1, 'int32');
+    // Create a range tensor for column indices and expand dimensions
+    const colIndices = tf.range(0, size, 1, 'int32').expandDims(1);
+    // Compare row and column indices to generate a boolean mask
+    const mask = tf.greater(rowIndices, colIndices);
+    // Apply mask and broadcast
+    const maskBroadcasted = new GTensor(mask, [dim1, dim2]).broadcastToCombinedShape(this)
+    const maskedM = tf.where(maskBroadcasted.tensor.reshape(this.tensor.shape), tf.scalar(upperTriangleConst).broadcastTo(this.tensor.shape), this.tensor);
+    return new GTensor(maskedM, this.dimNames);
   }
+
 }
+
 
 export class GVariable<G extends DName> extends GTensor<G> {
   variable: tf.Variable;

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -834,7 +834,7 @@ export class GTensor<G extends DName> {
     return new GTensor<Exclude<G, D> | G2>(gathered, newDimNames);
   }
 
-  public TriangularMask(dim1 : G, dim2: G, upper_triangle_const : number = 1, lower_triangle_const: number = 0): GTensor<G> {
+  public triangularMask(dim1 : G, dim2: G, upper_triangle_const : number = 1, lower_triangle_const: number = 0): GTensor<G> {
   /* Returns a triangular mask of the same shape as the provided GTensor
   with upper tril values set 'upper_triangle_const' (default = 1)
   and lower tril values set to 'lower_triangle_const' (default = 0)

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -860,10 +860,10 @@ export class GTensor<G extends DName> {
     // Compare row and column indices to generate a boolean mask
     const mask = tf.greater(rowIndices, colIndices);
     // Apply mask and broadcast
-    const maskBroadcasted = new GTensor(mask, [dim1, dim2]).broadcastToCombinedShape(this);
+    const maskBroadcasted = new GTensor(mask, [dim1, dim2]).broadcastToCombinedShape(this).transposeLike(this);
     // TODO laubrito: It might be a good idea to have a gtensor version of tf.where to avoid bradcasting errors
     const maskedM = tf.where(
-      maskBroadcasted.tensor.reshape(this.tensor.shape),
+      maskBroadcasted.tensor,
       tf.scalar(upperTriangleConst).broadcastTo(this.tensor.shape),
       this.tensor,
     );

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -81,7 +81,7 @@ interface ErrorNotAllowedName<OtherNames> {
 // Hack until can do more with the type system...
 function assertCommonNames<G extends string, G2 extends string>(
   g1: GTensor<G>,
-  g2: GTensor<G2>
+  g2: GTensor<G2>,
 ): void {
   const commonNames = g1.dimNames.filter((n) => n in g2.dim);
   if (commonNames.length === 0) {
@@ -96,16 +96,16 @@ type DotCompatibleDimension<
   M1 extends string,
   D1 extends M1,
   M2 extends string,
-  D2 extends M2
+  D2 extends M2,
 > = D2 extends never
   ? ErrorMustPassDimension
   : D1 extends D2
-  ? D2 extends D1
-    ? Exclude<M1 & M2, D1 & D2> extends never
-      ? Dimension<M2, D2>
-      : ErrorNotAllowedName<Exclude<M1 & M2, D2>>
-    : ErrorDimensionNamesMustBeEqual<D2, D1>
-  : ErrorDimensionNamesMustBeEqual<D1, D2>;
+    ? D2 extends D1
+      ? Exclude<M1 & M2, D1 & D2> extends never
+        ? Dimension<M2, D2>
+        : ErrorNotAllowedName<Exclude<M1 & M2, D2>>
+      : ErrorDimensionNamesMustBeEqual<D2, D1>
+    : ErrorDimensionNamesMustBeEqual<D1, D2>;
 
 type DisjointDimensions<G2 extends DName, G extends DName> = G2 & G extends never
   ? G2
@@ -123,19 +123,19 @@ interface ErrorLiftDimInOutput<D> {
 type DimensionFnToLift<D extends DName, G extends DName, G2 extends DName> = D extends G
   ? ErrorLiftDimInInput<D>
   : D extends G2
-  ? ErrorLiftDimInOutput<D>
-  : D;
+    ? ErrorLiftDimInOutput<D>
+    : D;
 
 export function liftGTensorFnOverDim<D extends string, G extends string, G2 extends string>(
   liftDim: DimensionFnToLift<D, G, G2>,
-  toLiftFn: (input: GTensor<G>) => GTensor<G2>
+  toLiftFn: (input: GTensor<G>) => GTensor<G2>,
 ): (input: GTensor<G | D>) => GTensor<G2 | D> {
   function liftedFn(input: GTensor<G | D>): GTensor<G2 | D> {
     if (!((liftDim as string) in input.dim)) {
       throw new ValueError(
         `The lift dimension ${String(liftDim)} must occur in input's dimensions: ${Object.keys(
-          input
-        )}`
+          input,
+        )}`,
       );
     }
     return toLiftFn(input as GTensor<G>) as GTensor<G2 | D>;
@@ -145,14 +145,14 @@ export function liftGTensorFnOverDim<D extends string, G extends string, G2 exte
 
 export function liftFnOverDim<D extends string, G extends string, G2 extends string>(
   liftDim: DimensionFnToLift<D, G, G2>,
-  toLiftFn: (input: Dims<G>) => Dims<G2>
+  toLiftFn: (input: Dims<G>) => Dims<G2>,
 ): (input: Dims<G | D>) => Dims<G2 | D> {
   function liftedFn(input: Dims<G | D>): Dims<G2 | D> {
     if (!((liftDim as string) in input)) {
       throw new ValueError(
         `The lift dimension ${String(liftDim)} must occur in input's dimensions: ${Object.keys(
-          input
-        )}`
+          input,
+        )}`,
       );
     }
     const unstackedDims = input[liftDim as D].unstack() as never as Dims<G>[];
@@ -165,10 +165,10 @@ export function liftMapFnOverDim<
   D extends string, // The new dimension being lifted over.
   G extends string, // The dimensions of the input.
   // A mapping from the name of each output of toLiftFn to the dimensions of that output.
-  MapDim extends { [key in keyof MapDim]: MapDim[keyof MapDim] }
+  MapDim extends { [key in keyof MapDim]: MapDim[keyof MapDim] },
 >(
   liftDim: DimensionFnToLift<D, G, MapDim[keyof MapDim]>,
-  toLiftFn: (input: Dims<G>) => { [key in keyof MapDim]: Dims<MapDim[key]> }
+  toLiftFn: (input: Dims<G>) => { [key in keyof MapDim]: Dims<MapDim[key]> },
 ): (input: Dims<G | D>) => { [key in keyof MapDim]: Dims<MapDim[key] | D> } {
   function liftedFn(input: Dims<G | D>): {
     [key in keyof MapDim]: Dims<MapDim[key] | D>;
@@ -176,8 +176,8 @@ export function liftMapFnOverDim<
     if (!((liftDim as string) in input)) {
       throw new ValueError(
         `The lift dimension ${String(liftDim)} must occur in input's dimensions: ${Object.keys(
-          input
-        )}`
+          input,
+        )}`,
       );
     }
     const unstackedDims = input[liftDim as D].unstack() as never as Dims<G>[];
@@ -278,7 +278,7 @@ export function gtensorOfDims<G extends string>(dims: Dims<G>): GTensor<G> {
 //
 export function stackGtensors<G extends string, NewD extends string>(
   newDimName: NewD,
-  gtensors: GTensor<G>[]
+  gtensors: GTensor<G>[],
 ): GTensor<G | NewD> {
   if (gtensors.length === 0) {
     throw new ValueError('stackDims was empty');
@@ -290,7 +290,7 @@ export function stackGtensors<G extends string, NewD extends string>(
 }
 export function stack<G extends string, NewD extends string>(
   newDimName: NewD,
-  stackDims: Dims<G>[]
+  stackDims: Dims<G>[],
 ): Dims<G | NewD> {
   const gtensors = stackDims.map(gtensorOfDims);
   return stackGtensors(newDimName, gtensors).dim;
@@ -417,7 +417,7 @@ export class GTensor<G extends DName> {
       } else if (g1d.size !== g2d.size) {
         throw new ValueError(
           `Mismatch on common dimension name ${String(g2d.name)}.` +
-            `sizes: ${g2d.size} vs ${g1d.size}`
+            `sizes: ${g2d.size} vs ${g1d.size}`,
         );
       } else {
         dimsToIgnore.push(g2d);
@@ -444,7 +444,7 @@ export class GTensor<G extends DName> {
 
     const bigTensor = tf.broadcastTo(
       this.tensor,
-      dimsToExpandBy.map((d) => d.size).concat(this.tensor.shape)
+      dimsToExpandBy.map((d) => d.size).concat(this.tensor.shape),
     );
 
     const combinedNames: (G | G2)[] = dimsToExpandBy
@@ -462,10 +462,10 @@ export class GTensor<G extends DName> {
   public broadcastTo<G2 extends DName>(newDimensions: Map<G2, number>): GTensor<G | G2> {
     const bigTensor = tf.broadcastTo(
       this.tensor,
-      [...newDimensions.values()].concat(this.tensor.shape)
+      [...newDimensions.values()].concat(this.tensor.shape),
     );
     const combinedNames: (G | G2)[] = ([...newDimensions.keys()] as (G | G2)[]).concat(
-      this.dimNames
+      this.dimNames,
     );
     return new GTensor(bigTensor, combinedNames);
   }
@@ -480,7 +480,7 @@ export class GTensor<G extends DName> {
     // TODO: update to using Map
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
     // renaming: { [Key in ReplacedNames]: NewNames }
-    renaming: Map<ReplacedNames, NewNames>
+    renaming: Map<ReplacedNames, NewNames>,
     // from: { [fromKey in G extends T1 ? T1 : never]: 'from' },
     // to: { [toKey in T2]: 'to' },
   ): GTensor<Exclude<G, ReplacedNames> | NewNames> {
@@ -495,7 +495,7 @@ export class GTensor<G extends DName> {
   // Rename a single dimension.
   public rename<T1 extends G, T2 extends DName>(
     fromName: T1,
-    toName: T2
+    toName: T2,
     // from: { [fromKey in G extends T1 ? T1 : never]: 'from' },
     // to: { [toKey in T2]: 'to' },
   ): GTensor<Exclude<G, T1> | T2> {
@@ -671,7 +671,7 @@ export class GTensor<G extends DName> {
     const g1bigLikeG2 = g1big.transposeLike(g2big);
     return new GTensor(
       tf.squaredDifference(g1bigLikeG2.tensor, g2big.tensor),
-      g1bigLikeG2.dimNames
+      g1bigLikeG2.dimNames,
     );
   }
 
@@ -679,7 +679,7 @@ export class GTensor<G extends DName> {
     const dimIndexes = dims.map((d) => this.dim[d].index);
     return new GTensor(
       tf.sum(this.tensor, dimIndexes),
-      this.dimNames.filter((d) => !dims.includes(d as D)) as Exclude<G, D>[]
+      this.dimNames.filter((d) => !dims.includes(d as D)) as Exclude<G, D>[],
     );
   }
 
@@ -687,7 +687,7 @@ export class GTensor<G extends DName> {
     const dimIndexes = dims.map((d) => this.dim[d].index);
     return new GTensor(
       tf.prod(this.tensor, dimIndexes),
-      this.dimNames.filter((d) => !dims.includes(d as D)) as Exclude<G, D>[]
+      this.dimNames.filter((d) => !dims.includes(d as D)) as Exclude<G, D>[],
     );
   }
 
@@ -723,7 +723,7 @@ export class GTensor<G extends DName> {
   // { [key in D2]: number }
   public splitDim<D extends G, D2 extends DName>(
     d: D,
-    newDims: { [key in D2]: number }
+    newDims: { [key in D2]: number },
   ): GTensor<Exclude<G, D> | D2> {
     const newDimsMap = new Map<D2, number>(Object.entries(newDims) as [D2, number][]);
     const oldShape = this.tensor.shape;
@@ -747,7 +747,7 @@ export class GTensor<G extends DName> {
 
   public mergeDims<D extends G, D2 extends DName>(
     ds: D[],
-    newDimName: DisjointDimensions<D2, G>
+    newDimName: DisjointDimensions<D2, G>,
   ): GTensor<Exclude<G, D> | D2> {
     const newShape: number[] = [];
     const newNames: (Exclude<G, D> | D2)[] = [];
@@ -771,13 +771,13 @@ export class GTensor<G extends DName> {
 
   public contract<G2 extends DName, D extends G2 & G>(
     g2: GTensor<G2>,
-    dimNames: D[]
+    dimNames: D[],
   ): GTensor<Exclude<G | G2, D>> {
     for (const d of dimNames) {
       if (g2.dim[d].size !== this.dim[d].size) {
         throw new Error(
           `contract dim name sizes must match for '${d}', ` +
-            `but they were: ${this.dim[d].size} and ${g2.dim[d].size}`
+            `but they were: ${this.dim[d].size} and ${g2.dim[d].size}`,
         );
       }
     }
@@ -791,7 +791,7 @@ export class GTensor<G extends DName> {
   public argMax<D extends G>(dim: D): GTensor<Exclude<G, D>> {
     return new GTensor(
       tf.argMax(this.tensor, this.dim[dim].index),
-      this.dimNames.filter((n) => n != dim) as Exclude<G, D>[]
+      this.dimNames.filter((n) => n != dim) as Exclude<G, D>[],
     );
   }
 
@@ -802,7 +802,7 @@ export class GTensor<G extends DName> {
   // TODO: support batched gather.
   public gather<D extends G, G2 extends DName>(
     indexes: GTensor<G2>,
-    dim: D
+    dim: D,
     // batchDimName?: G & G2,
   ): GTensor<Exclude<G, D> | G2> {
     // // batchDims.map(d => this.dim[d].index)
@@ -828,14 +828,14 @@ export class GTensor<G extends DName> {
     const gathered = tf.gather(
       this.tensor,
       indexes.tensor,
-      replacedIndex
+      replacedIndex,
       // batchDimName ? indexes.dim[batchDimName].index : undefined
     );
     return new GTensor<Exclude<G, D> | G2>(gathered, newDimNames);
   }
 
-  public triangularMask(dim1 : G, dim2: G, upperTriangleConst: number): GTensor<G> {
-  /* Applies a triangular mask to the provided GTensor
+  public triangularMask(dim1: G, dim2: G, upperTriangleConst: number): GTensor<G> {
+    /* Applies a triangular mask to the provided GTensor
   the values of the upper triangle are set 'upper_triangle_const'
 
   Parameters:
@@ -846,13 +846,11 @@ export class GTensor<G extends DName> {
   Note: Tensor will be broadcasted over additional dimension i.e. heads, batch.
   */
 
-    let size = this.dim[dim1].size
-    let size2 = this.dim[dim2].size
+    let size = this.dim[dim1].size;
+    let size2 = this.dim[dim2].size;
 
-    if (size !== size2){
-      throw new Error(
-        `Can't generate lower triangular mask for non square tensor `
-      );
+    if (size !== size2) {
+      throw new Error(`Can't generate lower triangular mask for non square tensor `);
     }
 
     // Create a range tensor for row indices
@@ -862,14 +860,23 @@ export class GTensor<G extends DName> {
     // Compare row and column indices to generate a boolean mask
     const mask = tf.greater(rowIndices, colIndices);
     // Apply mask and broadcast
-    const maskBroadcasted = new GTensor(mask, [dim1, dim2]).broadcastToCombinedShape(this)
+    const maskBroadcasted = new GTensor(mask, [dim1, dim2]).broadcastToCombinedShape(this);
     // TODO laubrito: It might be a good idea to have a gtensor version of tf.where to avoid bradcasting errors
-    const maskedM = tf.where(maskBroadcasted.tensor.reshape(this.tensor.shape), tf.scalar(upperTriangleConst).broadcastTo(this.tensor.shape), this.tensor);
+    const maskedM = tf.where(
+      maskBroadcasted.tensor.reshape(this.tensor.shape),
+      tf.scalar(upperTriangleConst).broadcastTo(this.tensor.shape),
+      this.tensor,
+    );
     return new GTensor(maskedM, this.dimNames);
   }
 
+  public softmaxCrossEntropy(oneHotLabels: GTensor<G>): GTensor<G> {
+    return new GTensor<G>(
+      tf.losses.softmaxCrossEntropy(oneHotLabels.tensor, this.tensor),
+      this.dimNames,
+    );
+  }
 }
-
 
 export class GVariable<G extends DName> extends GTensor<G> {
   variable: tf.Variable;
@@ -912,7 +919,7 @@ export function makeInitializer(config: InitializerConfig): tf_init.Initializer 
 export function fromInitializer<T extends string>(
   dims: { [key in T]: number },
   initialiser: tf_init.Initializer,
-  dtype?: tf.DataType
+  dtype?: tf.DataType,
 ): GTensor<T> {
   const dimNames = Object.keys(dims) as T[];
   const shape = dimNames.map((n: T) => dims[n]);
@@ -922,7 +929,7 @@ export function fromInitializer<T extends string>(
 export function makeTruncNormal<T extends string>(
   dims: { [key in T]: number },
   truncNormalConfig?: tf_init.TruncatedNormalArgs,
-  dtype?: tf.DataType
+  dtype?: tf.DataType,
 ): GTensor<T> {
   // TODO: Pass initWeight_stddev through instead of using globals
   return fromInitializer(
@@ -931,15 +938,15 @@ export function makeTruncNormal<T extends string>(
       truncNormalConfig || {
         stddev: 0.05, // window.__globalConfig?.initWeight_stddev || .05,
         mean: 0,
-      }
+      },
     ),
-    dtype
+    dtype,
   );
 }
 
 export function makeZeros<T extends string>(
   dims: { [key in T]: number },
-  dtype: tf.DataType = 'float32'
+  dtype: tf.DataType = 'float32',
 ): GTensor<T> {
   return fromInitializer(dims, tf.initializers.zeros(), dtype);
 }
@@ -947,7 +954,7 @@ export function makeZeros<T extends string>(
 export function identity<T extends string>(
   spec: { dimNames: [T, T]; size: number },
   identityArgs?: tf_init.IdentityArgs,
-  dtype?: tf.DataType
+  dtype?: tf.DataType,
 ): GTensor<T> {
   const dims: { [key in T]: number } = {} as { [key in T]: number };
   dims[spec.dimNames[0]] = spec.size;
@@ -960,7 +967,7 @@ export function identity<T extends string>(
 
 export function makeOnes<T extends string>(
   dims: { [key in T]: number },
-  dtype: tf.DataType = 'float32'
+  dtype: tf.DataType = 'float32',
 ): GTensor<T> {
   return fromInitializer(dims, tf.initializers.ones(), dtype);
 }
@@ -968,7 +975,7 @@ export function makeOnes<T extends string>(
 export function makeConstant<T extends string>(
   dims: { [key in T]: number },
   constant: number,
-  dtype: tf.DataType = 'float32'
+  dtype: tf.DataType = 'float32',
 ): GTensor<T> {
   return fromInitializer(dims, tf.initializers.constant({ value: constant }), dtype);
 }
@@ -978,19 +985,17 @@ export function makeRange<T extends DName>(
   start: number,
   end: number,
   step: number,
-  dtype: 'float32' | 'int32' = 'float32'
+  dtype: 'float32' | 'int32' = 'float32',
 ): GTensor<T> {
   return new GTensor<T>(tf.range(start, end, step, dtype), [dname]);
 }
 
 export function makeScalar(
   n: number,
-  dtype: 'float32' | 'int32' | 'bool' | 'complex64' | 'string' = 'float32'
+  dtype: 'float32' | 'int32' | 'bool' | 'complex64' | 'string' = 'float32',
 ): GTensor<never> {
   return new GTensor(tf.scalar(n, dtype), []);
 }
 
 export const one = makeScalar(1);
 export const zero = makeScalar(0);
-
-// TODO: Add softmaxCrossEntropy to the gtensor library

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -954,30 +954,34 @@ export function makeRange<T extends DName>(
   return new GTensor<T>(tf.range(start, end, step, dtype), [dname]);
 }
 
-/* Returns a 2D triangular mask of shape [size, size]
+/* Returns a 2D triangular matrix of shape [size, size]
  * Parameters:
- * - size: The dimension of the mask
- * - dimNames: Names of the dimensions of the final GTensor
- * - lowerLeftValue : All the values under the main diagonal and including the main diagonal will be replace by this value
- * - upperRightValue : All the entries avobe the main diagonal of the matrix will be replace by this value
+ * - size: The dimension of the matrix
+ * - d1Name: Name of the first dimension of the final GTensor
+ * - d2Name: Name of the second dimension of the final GTensor
+ * - lowerLeftValue : All the elements in and under the main diagonal will be replace by this value
+ * - upperRightValue : All the elements avobe the main diagonal of the matrix will be replace by this value
+ * - dtype : The type of an element in the resulting tensor. Defaults to 'float32'
  * // TODO add optianal broadcastTo dimensions/GTensor
  * */
-export function makeTriangularMatrix<N extends string, T extends string | number>(
+export function makeTriangularMatrix<N1 extends string, N2 extends string, T extends string | number>(
   size: number,
-  dimNames: N[],
+  d1Name: N1,
+  d2Name: N2,
   lowerLeftValue: T,
   upperRightValue: T,
-): GTensor<N> {
+  dtype: 'float32' | 'int32' | 'bool' | 'complex64' | 'string' = 'float32'
+): GTensor<N1 | N2> {
   // Create a range tensor for row indices
   const rowIndices = tf.range(0, size, 1, 'int32');
   // Create a range tensor for column indices and expand dimensions
   const colIndices = tf.range(0, size, 1, 'int32').expandDims(1);
-  // Compare row and column indices to generate a boolean mask. Apply the mask to a lowerLeftValue matrix and replace false values by upperRightValue
+  // Compare row and column indices to generate a boolean mask. Apply it to a lowerLeftValue matrix and replace false values by upperRightValue
   const triangularMatrix = new GTensor(
     tf
-      .fill([size, size], lowerLeftValue)
-      .where(tf.lessEqual(rowIndices, colIndices), tf.scalar(upperRightValue)),
-    dimNames,
+      .fill([size, size], lowerLeftValue, dtype)
+      .where(tf.lessEqual(rowIndices, colIndices), tf.scalar(upperRightValue, dtype)),
+    [d1Name, d2Name],
   );
 
   return triangularMatrix;

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -863,6 +863,7 @@ export class GTensor<G extends DName> {
     const mask = tf.greater(rowIndices, colIndices);
     // Apply mask and broadcast
     const maskBroadcasted = new GTensor(mask, [dim1, dim2]).broadcastToCombinedShape(this)
+    // TODO laubrito: It might be a good idea to have a gtensor version of tf.where to avoid bradcasting errors
     const maskedM = tf.where(maskBroadcasted.tensor.reshape(this.tensor.shape), tf.scalar(upperTriangleConst).broadcastTo(this.tensor.shape), this.tensor);
     return new GTensor(maskedM, this.dimNames);
   }
@@ -991,3 +992,5 @@ export function makeScalar(
 
 export const one = makeScalar(1);
 export const zero = makeScalar(0);
+
+// TODO: Add softmaxCrossEntropy to the gtensor library

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -40,6 +40,7 @@ import * as tf from '@tensorflow/tfjs';
 import * as tf_init from '@tensorflow/tfjs-layers/dist/initializers';
 import { contract, ContractSpec } from './contract';
 import { range } from './gtensor_util';
+import { number } from 'yargs';
 
 // export type DName = string | number | symbol;
 
@@ -833,20 +834,22 @@ export class GTensor<G extends DName> {
     return new GTensor<Exclude<G, D> | G2>(gathered, newDimNames);
   }
 
-  public TriangularMask<D extends G>(dims: D[], upper_triangle_const : number = 1, lower_triangle_const: number = 0): GTensor<G> {
-  /*Returns a triangular mask of the same shape as the provided GTensor
+  public TriangularMask(dim1 : G, dim2: G, upper_triangle_const : number = 1, lower_triangle_const: number = 0): GTensor<G> {
+  /* Returns a triangular mask of the same shape as the provided GTensor
   with upper tril values set 'upper_triangle_const' (default = 1)
   and lower tril values set to 'lower_triangle_const' (default = 0)
 
   Parameters:
-  - dims: The list of dimensions to mask over. Expected Pos1, Pos2 (expected to be of the same size).
-    Tensor will be broadcasted over additional dimension i.e. heads, batch
+  - dim1: First dimension of the triangular mask matrix (Should exist in the GTensor)
+  - dim2: First dimension of the triangular mask matrix (Should exist in the GTensor)
   - upper_triangle_const = constant to fill the upper triangle of the matrix, default = 1
   - lower_triangle_const = constant to fill the lower triangle of the matrix, default = 0
+
+  Note: Tensor will be broadcasted over additional dimension i.e. heads, batch.
   */
 
-    let Pos_2 = this.dim[dims[1]].size
-    let Pos = this.dim[dims[2]].size
+    let Pos_2 = this.dim[dim1].size
+    let Pos = this.dim[dim2].size
 
     if (Pos !== Pos_2){
       throw new Error(
@@ -865,7 +868,7 @@ export class GTensor<G extends DName> {
     let tril_mask = tril_aux.add(triu_aux)
 
     // Broadcast over batch and heads Dimension
-    let gtril_mask_broadcasted = new GTensor(tril_mask, [dims[1], dims[2]]).broadcastToCombinedShape(this)
+    let gtril_mask_broadcasted = new GTensor(tril_mask, [dim1, dim2]).broadcastToCombinedShape(this)
     return gtril_mask_broadcasted;
   }
 }

--- a/animated-transformer/src/lib/gtensor/gtensor.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.ts
@@ -834,17 +834,16 @@ export class GTensor<G extends DName> {
     return new GTensor<Exclude<G, D> | G2>(gathered, newDimNames);
   }
 
-  public triangularMask(dim1: G, dim2: G, upperTriangleConst: number): GTensor<G> {
-    /* Applies a triangular mask to the provided GTensor
-  the values of the upper triangle are set 'upper_triangle_const'
-
-  Parameters:
-  - dim1: First dimension of the triangular mask matrix (Should exist in the GTensor)
-  - dim2: First dimension of the triangular mask matrix (Should exist in the GTensor)
-  - upper_triangle_const = constant to fill the upper triangle of the matrix
-
-  Note: Tensor will be broadcasted over additional dimension i.e. heads, batch.
+  /* Applies a Lower triangular mask to the provided GTensor
+  *
+  * Parameters:
+  * - dim1: Name of the First dimension of the triangular mask (Should exist in the GTensor)
+  * - dim2: Name of the Second dimension of the triangular mask (Should exist in the GTensor)
+  * - upperTriangleConst : All the entries avobe the main diagonal of the matrix will be replace by this value (default = 0)
+  *
+  * Note: Tensor will be broadcasted over additional dimension i.e. heads, batch.
   */
+  public triangularMask(dim1: G, dim2: G, upperTriangleConst: number = 0): GTensor<G> {
 
     let size = this.dim[dim1].size;
     let size2 = this.dim[dim2].size;

--- a/animated-transformer/src/lib/seqtasks/tiny_worlds_train_self_att.script.ts
+++ b/animated-transformer/src/lib/seqtasks/tiny_worlds_train_self_att.script.ts
@@ -36,13 +36,13 @@ import {
   transformerAccuracy,
   TransformerModel,
   initDecoderParams,
-  AllPastTokensCrossEntropyLoss,
+  allPastTokensCrossEntropyLoss,
 } from '../transformer/transformer_gtensor';
 import { TinyWorldTask, TinyWorldTaskConfig, defaultTinyWorldTaskConfig } from './tiny_worlds';
 import {
   strSeqPrepFn,
   singleNextTokenIdxOutputPrepFn,
-  nextTokenPerPosIdxOutputPrepFn,
+  expectedOutputSeqPrepFn,
   prepareBasicTaskTokenRep,
 } from '../tokens/token_gemb';
 import * as yargs from 'yargs';
@@ -134,8 +134,8 @@ function computeLoss(
     batchInput,
     randomStream
   );
-  const nextTokenOneHot = nextTokenPerPosIdxOutputPrepFn(model, batchInput, batchOutput);
-  const entropyLoss: tf.Scalar = AllPastTokensCrossEntropyLoss(model, computation, nextTokenOneHot);
+  const targetTokensOneHot = expectedOutputSeqPrepFn(model, batchInput, batchOutput);
+  const entropyLoss: tf.Scalar = allPastTokensCrossEntropyLoss(model, computation, targetTokensOneHot);
   if (batchId % printEveryNBatches === 0) {
     console.log(
       `batch: ${batchId} `.padEnd(15) +

--- a/animated-transformer/src/lib/seqtasks/tiny_worlds_train_self_att.script.ts
+++ b/animated-transformer/src/lib/seqtasks/tiny_worlds_train_self_att.script.ts
@@ -1,0 +1,249 @@
+/* Copyright 2023 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/*
+
+Tiny Worlds, run with (gtensor-based) transformers.
+
+TODO: add yargs so this is a real command line tool example.
+
+Run:
+  npx ts-node src/lib/seqtasks/tiny_worlds_train.script.ts
+*/
+
+import * as tf from '@tensorflow/tfjs-node';
+
+import {
+  TransformerParamLayerSpec,
+  TransformerParamSpec,
+  TransformerConfig,
+  TransformerParams,
+  TransformerComputation,
+  computeDecoder,
+  lastTokenLogits,
+  lastTokenCrossEntropyLoss,
+  transformerAccuracy,
+  TransformerModel,
+  initDecoderParams,
+  AllPastTokensCrossEntropyLoss,
+} from '../transformer/transformer_gtensor';
+import { TinyWorldTask, TinyWorldTaskConfig, defaultTinyWorldTaskConfig } from './tiny_worlds';
+import {
+  strSeqPrepFn,
+  singleNextTokenIdxOutputPrepFn,
+  NextTokenPerPosIdxOutputPrepFn,
+  prepareBasicTaskTokenRep,
+} from '../tokens/token_gemb';
+import * as yargs from 'yargs';
+import { varifyParams, listifyVarParams } from '../gtensor/params';
+import { RandomStream, makeRandomStream } from '../random/random';
+
+const tfjsBackendName = tf.getBackend();
+console.log('tfjs backend:', tfjsBackendName);
+
+const printEveryNBatches = 10;
+
+function getTaskConfig(): TinyWorldTaskConfig {
+  const taskConfig: TinyWorldTaskConfig = {
+    ...defaultTinyWorldTaskConfig,
+    maxInputLen: 10,
+    maxOutputLen: 1,
+  };
+  return taskConfig;
+}
+
+function initTransformerConfig(baseVocab: string[]): TransformerConfig {
+  const layer_config: TransformerParamLayerSpec = {
+    nHeads: 4,
+    hasPosEncoding: false,
+    // There may be a problem with layer norm; it seems to stop it from learning.
+    // With laynorm off, we get entropyLoss: 1.05391383  accuracy: 0.53125000
+    // with it on, we get lowest entropyLoss: 1.7 ish, and accuracy: ~0.35
+    layerNormFF: false,
+    layerNormHeadsProjection: false,
+    addLayerNormBias: false,
+    computeSpec: { residuals: true, dropoutRate: 0 },
+  };
+  const layer_config_first: TransformerParamLayerSpec = {
+    ...layer_config,
+    hasPosEncoding: false,
+  };
+  const spec: TransformerParamSpec = {
+    inputRep: 64,
+    kqvRep: 64,
+    dropoutRate: 0,
+    layers: [layer_config_first, layer_config, layer_config, layer_config],
+  };
+  const config: TransformerConfig = {
+    id: 'a simple transformer',
+    kind: 'Transformer',
+    spec: spec,
+    tokenRep: prepareBasicTaskTokenRep(baseVocab),
+    init: {
+      stddev: 0.05, // default
+      mean: 0,
+      seed: 42,
+    },
+  };
+  return config;
+}
+
+type Batch = {
+  batchId: number;
+  inputs: string[][];
+  outputs: string[][];
+};
+
+function* batchGenerator(
+  task: TinyWorldTask,
+  batchNum: number,
+  batchSize: number
+): Iterable<Batch> {
+  for (let batchId = 0; batchId < batchNum; batchId += 1) {
+    let batchOriginal = task.exampleIter.takeOutN(batchSize);
+    let inputs = batchOriginal.map((example) => example.input);
+    let outputs = batchOriginal.map((example) => example.output);
+    yield { batchId, inputs, outputs };
+  }
+}
+
+function computeLoss(
+  model: {
+    config: TransformerConfig;
+    params: TransformerParams;
+  },
+  randomStream: RandomStream,
+  batchId: number,
+  batchInput: string[][],
+  batchOutput: string[][]
+): tf.Scalar {
+  const computation: TransformerComputation = computeDecoder(
+    model,
+    strSeqPrepFn,
+    batchInput,
+    randomStream
+  );
+  const nextTokenOneHot = NextTokenPerPosIdxOutputPrepFn(model, batchInput, batchOutput);
+  const entropyLoss: tf.Scalar = AllPastTokensCrossEntropyLoss(model, computation, nextTokenOneHot);
+  if (batchId % printEveryNBatches === 0) {
+    console.log(
+      `batch: ${batchId} `.padEnd(15) +
+        ('entropyLoss: ' + entropyLoss.arraySync().toFixed(8)).padEnd(25)
+    );
+  }
+  return entropyLoss;
+}
+
+function run() {
+  // define task
+  const trainTaskConfig = getTaskConfig();
+  const trainTask = new TinyWorldTask(trainTaskConfig);
+
+  // define vocab & decoder
+  const transformerConfig = initTransformerConfig(trainTask.baseVocab);
+  const decoderParams = varifyParams(initDecoderParams(transformerConfig));
+  const model: TransformerModel = {
+    config: transformerConfig,
+    params: decoderParams,
+  };
+  const randomStream = makeRandomStream(42);
+
+  // By manipulating decoderParams, you can selectively limit what parameters
+  // get tuned.
+  const paramsList = listifyVarParams(decoderParams).map((g) => g.variable);
+
+  {
+    // train with optimiztaion
+    const batchNum: number = 300;
+    const batchSize: number = 64;
+
+    let optimizer = tf.train.adam();
+    for (let batch of batchGenerator(trainTask, batchNum, batchSize)) {
+      let { batchId, inputs, outputs } = batch;
+      optimizer.minimize(
+        () => computeLoss(model, randomStream, batchId, inputs, outputs),
+        false,
+        paramsList
+      );
+      batchId += 1;
+    }
+    optimizer.dispose();
+  }
+
+  {
+    // infer
+    const inferSteps = 5;
+    const inferTaskConfig = { ...getTaskConfig(), maxOutputLen: inferSteps };
+    const inferTask = new TinyWorldTask(inferTaskConfig);
+
+    const batchOriginal = inferTask.exampleIter.takeOutN(1);
+
+    batchOriginal.forEach((e) =>
+      console.log(`(${e.id}) ${e.input.join('')} ---> ${e.output.join('')}`)
+    );
+
+    const batchInputAll = batchOriginal.map((example) => example.input);
+    const batchOutputAll = batchOriginal.map((example) => example.output);
+    let batchInput = batchInputAll;
+    // Make the batch output only have a single next token.
+    let batchOutput = batchOutputAll.map((subarr) => subarr.slice(0, 1));
+
+    // for (let inferStep = 0; inferStep < inferSteps; inferStep += 1) {
+    const inferStep = 0;
+    const spec = transformerConfig.spec;
+    const computation: TransformerComputation = computeDecoder(
+      model,
+      strSeqPrepFn,
+      batchInput,
+      randomStream
+    );
+    //
+    const singleNextTokenIdx = singleNextTokenIdxOutputPrepFn(model, batchOutput);
+    // [0] to look at only the first example in batch.
+    const singleNextTokenIdxArrayData = (singleNextTokenIdx.tensor.arraySync() as number[])[0];
+    const logits = lastTokenLogits(model, computation);
+    // TODO: tensor.arraySync() doesn't provide any guarentee for the ordering of outputs,
+    // we need to use the right gtensor functions to get the output we want...
+    // [0] to look at only the first example in batch.
+    const logitsArr = (logits.tensor.arraySync() as number[][])[0];
+    let probs = logits.softmax('tokenId');
+    // [0] to look at only the first example in batch.
+    let probsArrayData = (probs.tensor.arraySync() as number[][])[0];
+
+    // Create a sorted table of information for each token.
+    const possibleTokenTable = probsArrayData.map((prob, i) => {
+      return { str: model.config.tokenRep.tokens[i], tokenId: i, prob: prob, logit: logitsArr[i] };
+    });
+    possibleTokenTable.sort((a, b) => b.prob - a.prob);
+
+    console.log('Inference Step:', inferStep);
+    console.log('Context:', batchInput[0].join(''));
+    // console.log('Target Output:', batchOutput[0].join(''));
+    console.log('Target next token:', batchOutput[0][0]);
+    console.log('Prediction:');
+    console.log('   ', 'token'.padEnd(10), ' ', 'prob'.padEnd(10), ' ');
+
+    // Print the sorted table, marking the target from the batchOutput.
+    for (const token of possibleTokenTable) {
+      // let tokenId = 0; tokenId < tokenRep.tokens.length; tokenId += 1
+      let mark = '';
+      if (token.tokenId == singleNextTokenIdxArrayData) {
+        mark = ' <- Target';
+      }
+      console.log('   ', token.str.padEnd(10), ' ', token.prob.toFixed(8), ' ', mark);
+    }
+  } // infer
+} // run
+
+run();

--- a/animated-transformer/src/lib/seqtasks/tiny_worlds_train_self_att.script.ts
+++ b/animated-transformer/src/lib/seqtasks/tiny_worlds_train_self_att.script.ts
@@ -42,7 +42,7 @@ import { TinyWorldTask, TinyWorldTaskConfig, defaultTinyWorldTaskConfig } from '
 import {
   strSeqPrepFn,
   singleNextTokenIdxOutputPrepFn,
-  NextTokenPerPosIdxOutputPrepFn,
+  nextTokenPerPosIdxOutputPrepFn,
   prepareBasicTaskTokenRep,
 } from '../tokens/token_gemb';
 import * as yargs from 'yargs';
@@ -134,7 +134,7 @@ function computeLoss(
     batchInput,
     randomStream
   );
-  const nextTokenOneHot = NextTokenPerPosIdxOutputPrepFn(model, batchInput, batchOutput);
+  const nextTokenOneHot = nextTokenPerPosIdxOutputPrepFn(model, batchInput, batchOutput);
   const entropyLoss: tf.Scalar = AllPastTokensCrossEntropyLoss(model, computation, nextTokenOneHot);
   if (batchId % printEveryNBatches === 0) {
     console.log(

--- a/animated-transformer/src/lib/tokens/token_gemb.spec.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.spec.ts
@@ -146,7 +146,7 @@ describe('token_gemb', () => {
       batchOutput,
     );
 
-    const expectedOutputArr: [Array<Array<number>>, Array<Array<number>>] = [
+    const expectedOutputArr: number[][][] = [
       [
         [0, 1, 0, 0, 0, 0],
         [1, 0, 0, 0, 0, 0],

--- a/animated-transformer/src/lib/tokens/token_gemb.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.ts
@@ -288,11 +288,11 @@ export function singleNextTokenIdxOutputPrepFn(
   expectedOutputs: string[][],
 ): GTensor<'batch' | 'pos' | 'tokenId'> {
   // Compute Token rep for inputSeq
-  const inputSeq = inputSeqs.map((SingleSample) => SingleSample.map((token) => model.config.tokenRep.tokenToIdx[token]))
+  const batchInputs = inputSeqs.map((inputSeq) => inputSeq.map((token) => model.config.tokenRep.tokenToIdx[token]))
    // Compute Token rep for inputSeq
   const expectedOutputSeq = expectedOutputs.map((outputToken) => model.config.tokenRep.tokenToIdx[outputToken[0]])
   // Shift input sequences to the right and add the corresponding target in "expectedOutputs" at the end of each sequence
-  let shiftedInputs = inputSeq.map((x) => x.slice(1, ))
+  let shiftedInputs = batchInputs.map((x) => x.slice(1, ))
   const expectedOutputSeqIdx = expectedOutputSeq.map((y, index) => shiftedInputs[index].concat(y))
   const expectedOutputSeqOneHot = expectedOutputSeqIdx.map((sample) => sample.map((tidx) => model.config.tokenRep.idxToOneHot[tidx]))
   // TODO: We should probably be using a lookup function and storing the one-hot for every token in the GPU as a constant.

--- a/animated-transformer/src/lib/tokens/token_gemb.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.ts
@@ -149,6 +149,7 @@ export type BasicTaskTokenRep = {
   maskToken: string;
   padToken: string;
   eosToken: string;
+  spaceToken: string;
   // tokens is all tokens, including mask, pod, eos, etc
   tokens: string[];
   tokenToIdx: { [token: string]: number };
@@ -162,6 +163,7 @@ export function prepareBasicTaskTokenRep(baseVocab: string[]): BasicTaskTokenRep
   const maskToken = '[MASK]';
   const padToken = '[PAD]';
   const eosToken = '[EOS]';
+  const spaceToken = ' '
   const vocab = [...baseVocab, maskToken, padToken, eosToken];
   const tokenToIdx: { [token: string]: number } = {};
   vocab.forEach((t, i) => (tokenToIdx[t] = i));
@@ -174,6 +176,7 @@ export function prepareBasicTaskTokenRep(baseVocab: string[]): BasicTaskTokenRep
     maskToken,
     padToken,
     eosToken,
+    spaceToken,
     tokens: vocab,
     tokenToIdx,
   };

--- a/animated-transformer/src/lib/tokens/token_gemb.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.ts
@@ -174,6 +174,7 @@ export function prepareBasicTaskTokenRep(baseVocab: string[]): BasicTaskTokenRep
   //   makeTruncNormal({ token: vocab.length, inputRep: repSize })
   // );
 
+  // TODO: Find a better place for the idxToOneHot lookup table
   const idxToOneHot : {[tokenIdx: number]: number[] } = {};
   const oneHotTokens : number[] | any[] = [tf.oneHot(tf.tensor1d(Object.values(tokenToIdx), 'int32'), baseVocab.length + 4).arraySync()];
   Object.values(tokenToIdx).forEach((i) => (idxToOneHot[i] = oneHotTokens[0][i]));
@@ -284,7 +285,7 @@ export function singleNextTokenIdxOutputPrepFn(
  - One contains the list of targets per token/position in each sample of the batch
  - The other contains the tokenId representation of the tokens on the previous list
 */
- export function NextTokenPerPosIdxOutputPrepFn(
+ export function nextTokenPerPosIdxOutputPrepFn(
   model: { config: { tokenRep: BasicTaskTokenRep } },
   inputSeqs: string[][],
   expectedOutputs: string[][],

--- a/animated-transformer/src/lib/tokens/token_gemb.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.ts
@@ -176,7 +176,7 @@ export function prepareBasicTaskTokenRep(baseVocab: string[]): BasicTaskTokenRep
 
   // TODO: Find a better place for the idxToOneHot lookup table
   const idxToOneHot : {[tokenIdx: number]: number[] } = {};
-  const oneHotTokens : number[] | any[] = [tf.oneHot(tf.tensor1d(Object.values(tokenToIdx), 'int32'), baseVocab.length + 4).arraySync()];
+  const oneHotTokens = [tf.oneHot(tf.tensor1d(Object.values(tokenToIdx), 'int32'), baseVocab.length + 4).arraySync() as number[][]];
   Object.values(tokenToIdx).forEach((i) => (idxToOneHot[i] = oneHotTokens[0][i]));
   return {
     maskToken,

--- a/animated-transformer/src/lib/tokens/token_gemb.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.ts
@@ -165,7 +165,7 @@ export function prepareBasicTaskTokenRep(baseVocab: string[]): BasicTaskTokenRep
   const padToken = '[PAD]';
   const eosToken = '[EOS]';
   const spaceToken = ' '
-  const vocab = [spaceToken, ...baseVocab, maskToken, padToken, eosToken];
+  const vocab = [ ...baseVocab, maskToken, padToken, eosToken, spaceToken];
   const tokenToIdx: { [token: string]: number } = {};
   vocab.forEach((t, i) => (tokenToIdx[t] = i));
 

--- a/animated-transformer/src/lib/tokens/token_gemb.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.ts
@@ -165,7 +165,7 @@ export function prepareBasicTaskTokenRep(baseVocab: string[]): BasicTaskTokenRep
   const padToken = '[PAD]';
   const eosToken = '[EOS]';
   const spaceToken = ' '
-  const vocab = [...baseVocab, maskToken, padToken, eosToken];
+  const vocab = [spaceToken, ...baseVocab, maskToken, padToken, eosToken];
   const tokenToIdx: { [token: string]: number } = {};
   vocab.forEach((t, i) => (tokenToIdx[t] = i));
 
@@ -173,6 +173,7 @@ export function prepareBasicTaskTokenRep(baseVocab: string[]): BasicTaskTokenRep
   //   vocab,
   //   makeTruncNormal({ token: vocab.length, inputRep: repSize })
   // );
+
   const idxToOneHot : {[tokenIdx: number]: number[] } = {};
   const oneHotTokens : number[] | any[] = [tf.oneHot(tf.tensor1d(Object.values(tokenToIdx), 'int32'), baseVocab.length + 4).arraySync()];
   Object.values(tokenToIdx).forEach((i) => (idxToOneHot[i] = oneHotTokens[0][i]));
@@ -278,17 +279,16 @@ export function singleNextTokenIdxOutputPrepFn(
     ['batch']
   );
 }
-
 /*
  Creates two GTensors:
  - One contains the list of targets per token/position in each sample of the batch
  - The other contains the tokenId representation of the tokens on the previous list
 */
-export function NextTokenPerPosIdxOutputPrepFn(
+ export function NextTokenPerPosIdxOutputPrepFn(
   model: { config: { tokenRep: BasicTaskTokenRep } },
   inputSeqs: string[][],
   expectedOutputs: string[][],
-): [GTensor<'batch' | 'pos' | 'tokenId'>, GTensor<'batch' | 'pos'>] {
+): GTensor<'batch' | 'pos' | 'tokenId'> {
   // Compute Token rep for inputSeq
   const inputTokenRep = inputSeqs.map((SingleSample) => SingleSample.map((token) => model.config.tokenRep.tokenToIdx[token]))
    // Compute Token rep for inputSeq
@@ -297,9 +297,9 @@ export function NextTokenPerPosIdxOutputPrepFn(
   let shiftedInputs = inputTokenRep.map((x) => x.slice(1, ))
   const idxTargets = outTokenRep.map((y, index) => shiftedInputs[index].concat(y))
   const oneHotTargets = idxTargets.map((sample) => sample.map((tidx) => model.config.tokenRep.idxToOneHot[tidx]))
-  return [new GTensor(tf.tensor(oneHotTargets),['batch', 'pos', 'tokenId']),
-    new GTensor(tf.tensor(idxTargets),['batch', 'pos'])];
+  return new GTensor(tf.tensor(oneHotTargets),['batch', 'pos', 'tokenId']);
 }
+
 
 export function padInputSeqStart(
   paddingToken: string,

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
@@ -110,7 +110,7 @@ describe('GTensor Transformers', () => {
       ]),
       ['batch', 'heads', 'keyPos', 'queryPos'],
     );
-    const masked = exampleAffinities.triangularMask('keyPos', 'queryPos', -Infinity).softmax('queryPos');
+    const masked = exampleAffinities.pointwiseAdd(exampleAffinities.triangularMask('keyPos', 'queryPos', -Infinity)).softmax('queryPos');
 
     expect(masked.dimNames).toEqual(['batch', 'heads', 'keyPos', 'queryPos']);
     tf.test_util.expectArraysClose(masked.tensor.arraySync(), [

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
@@ -110,7 +110,7 @@ describe('GTensor Transformers', () => {
       ]),
       ['batch', 'heads', 'keyPos', 'queryPos'],
     );
-    const masked = exampleAffinities.pointwiseAdd(causalMask(exampleAffinities));
+    const masked = causalMask(exampleAffinities);
 
     expect(masked.dimNames).toEqual(['batch', 'heads', 'keyPos', 'queryPos']);
     tf.test_util.expectArraysClose(masked.tensor.arraySync(), [

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import { GTensor, makeTruncNormal } from '../gtensor/gtensor';
 import * as transformer from './transformer_gtensor';
-import { AttnHeadParamSpec, AttnHeadComputeSpec } from './transformer_gtensor';
+import { AttnHeadParamSpec, AttnHeadComputeSpec, causalMask } from './transformer_gtensor';
 import * as tf from '@tensorflow/tfjs';
 import * as abtask from '../seqtasks/ab_task';
 import { embedBatch, prepareBasicTaskTokenRep } from '../tokens/token_gemb';
@@ -110,7 +110,7 @@ describe('GTensor Transformers', () => {
       ]),
       ['batch', 'heads', 'keyPos', 'queryPos'],
     );
-    const masked = exampleAffinities.pointwiseAdd(exampleAffinities.triangularMask('keyPos', 'queryPos', -Infinity)).softmax('queryPos');
+    const masked = exampleAffinities.pointwiseAdd(causalMask(exampleAffinities));
 
     expect(masked.dimNames).toEqual(['batch', 'heads', 'keyPos', 'queryPos']);
     tf.test_util.expectArraysClose(masked.tensor.arraySync(), [

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import { GTensor, makeTruncNormal } from '../gtensor/gtensor';
 import * as transformer from './transformer_gtensor';
-import { AttnHeadParamSpec, AttnHeadComputeSpec } from './transformer_gtensor';
+import { AttnHeadParamSpec, AttnHeadComputeSpec, ComputeMaskedAffinities } from './transformer_gtensor';
 import * as tf from '@tensorflow/tfjs';
 import * as abtask from '../seqtasks/ab_task';
 import { embedBatch, prepareBasicTaskTokenRep } from '../tokens/token_gemb';
@@ -95,5 +95,26 @@ describe('GTensor Transformers', () => {
       pos: task.config.maxInputLen + 1,
       inputRep,
     });
+  });
+
+  it('Compute masked self attention', () => {
+    const exampleAffinities = new GTensor(
+      tf.tensor([[
+        [
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+        ],
+      ]]),
+      ['batch', 'heads', 'keyPos', 'queryPos']
+    );
+    const masked = ComputeMaskedAffinities(exampleAffinities).softmax('queryPos');
+
+    expect(masked.dimNames).toEqual(['batch', 'heads', 'keyPos', 'queryPos']);
+    tf.test_util.expectArraysClose(masked.tensor.arraySync(),
+      [[[[1, 0, 0],
+      [0.5, 0.5, 0],
+      [0.33, 0.33, 0.33]]
+    ]]);
   });
 });

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import { GTensor, makeTruncNormal } from '../gtensor/gtensor';
 import * as transformer from './transformer_gtensor';
-import { AttnHeadParamSpec, AttnHeadComputeSpec, computeMaskedAffinities } from './transformer_gtensor';
+import { AttnHeadParamSpec, AttnHeadComputeSpec } from './transformer_gtensor';
 import * as tf from '@tensorflow/tfjs';
 import * as abtask from '../seqtasks/ab_task';
 import { embedBatch, prepareBasicTaskTokenRep } from '../tokens/token_gemb';
@@ -110,7 +110,7 @@ describe('GTensor Transformers', () => {
       ]),
       ['batch', 'heads', 'keyPos', 'queryPos'],
     );
-    const masked = computeMaskedAffinities(exampleAffinities).softmax('queryPos');
+    const masked = exampleAffinities.triangularMask('keyPos', 'queryPos', -Infinity).softmax('queryPos');
 
     expect(masked.dimNames).toEqual(['batch', 'heads', 'keyPos', 'queryPos']);
     tf.test_util.expectArraysClose(masked.tensor.arraySync(), [

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import { GTensor, makeTruncNormal } from '../gtensor/gtensor';
 import * as transformer from './transformer_gtensor';
-import { AttnHeadParamSpec, AttnHeadComputeSpec, ComputeMaskedAffinities } from './transformer_gtensor';
+import { AttnHeadParamSpec, AttnHeadComputeSpec, computeMaskedAffinities } from './transformer_gtensor';
 import * as tf from '@tensorflow/tfjs';
 import * as abtask from '../seqtasks/ab_task';
 import { embedBatch, prepareBasicTaskTokenRep } from '../tokens/token_gemb';
@@ -45,12 +45,12 @@ describe('GTensor Transformers', () => {
           [5, 6],
         ],
       ]),
-      ['batch', 'pos', 'inputRep']
+      ['batch', 'pos', 'inputRep'],
     );
     const generator = makeRandomStream(0);
     const parts = transformer.computeAttnHead(spec, params, inputExample1, generator);
     expect(parts.attendedValues.dimNames).toEqual(
-      jasmine.arrayContaining(['batch', 'heads', 'value', 'pos'])
+      jasmine.arrayContaining(['batch', 'heads', 'value', 'pos']),
     );
     expect(parts.attendedValues.gshape()).toEqual({
       batch: 1,
@@ -86,7 +86,7 @@ describe('GTensor Transformers', () => {
       tokenRep.tokenToIdx,
       embeddings,
       examples.map((example) => example.input.concat(tokenRep.maskToken)),
-      { paddingId: padTokenId, padAt: 'start', dtype: 'int32' }
+      { paddingId: padTokenId, padAt: 'start', dtype: 'int32' },
     );
 
     expect(batchedInputEmb.gshape()).toEqual({
@@ -99,22 +99,28 @@ describe('GTensor Transformers', () => {
 
   it('Compute masked self attention', () => {
     const exampleAffinities = new GTensor(
-      tf.tensor([[
+      tf.tensor([
         [
-          [0, 0, 0],
-          [0, 0, 0],
-          [0, 0, 0],
+          [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+          ],
         ],
-      ]]),
-      ['batch', 'heads', 'keyPos', 'queryPos']
+      ]),
+      ['batch', 'heads', 'keyPos', 'queryPos'],
     );
-    const masked = ComputeMaskedAffinities(exampleAffinities).softmax('queryPos');
+    const masked = computeMaskedAffinities(exampleAffinities).softmax('queryPos');
 
     expect(masked.dimNames).toEqual(['batch', 'heads', 'keyPos', 'queryPos']);
-    tf.test_util.expectArraysClose(masked.tensor.arraySync(),
-      [[[[1, 0, 0],
-      [0.5, 0.5, 0],
-      [0.33, 0.33, 0.33]]
-    ]]);
+    tf.test_util.expectArraysClose(masked.tensor.arraySync(), [
+      [
+        [
+          [1, 0, 0],
+          [0.5, 0.5, 0],
+          [0.33, 0.33, 0.33],
+        ],
+      ],
+    ]);
   });
 });

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -358,7 +358,9 @@ export function computeAttnHead(
       .scalarDiv(makeScalar(Math.sqrt(seqInput.dim.inputRep.size), 'float32'));
   }
 
-  const attention = rawAttention.softmax('queryPos');
+  const maskedAffinities = ComputeMaskedAffinities(rawAttention); // Uncomment this and the next lines to compute Masked Attention
+  const attention = maskedAffinities.softmax('queryPos'); // Uncomment this and the previous lines to compute Masked Attention
+  //const attention = rawAttention.softmax('queryPos'); // Uncomment this line to compute Unmasked self attention
 
   // Dropout on the attention weights.
   const attentionAfterDropout = dropout(spec.dropoutRate, attention, generator.random());

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -323,7 +323,8 @@ export function causalMask(
 ): GTensor<'batch' | 'heads' | 'keyPos' | 'queryPos'> {
   const triangularMatrix = makeTriangularMatrix(
     qk.dim['queryPos'].size,
-    ['keyPos', 'queryPos'],
+    'keyPos',
+    'queryPos',
     0,
     -Infinity,
   ).broadcastToCombinedShape(qk);

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -354,7 +354,7 @@ export function computeAttnHead(
   // TODO: eventually we would like to pass in precomputed attention mask to the function,
   // rather than recompute attention masks inference pass
 
-  const maskedAffinities = rawAttention.triangularMask('keyPos', 'queryPos', -Infinity);
+  const maskedAffinities = rawAttention.pointwiseAdd(rawAttention.triangularMask('keyPos', 'queryPos', -Infinity));
   const attention = maskedAffinities.softmax('queryPos');
   const attentionAfterDropout = dropout(spec.dropoutRate, attention, generator.random());
 

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -316,10 +316,10 @@ function gelu(x: tf.Tensor) {
   return tf.mul(x, cdf);
 }
 
-export function ComputeMaskedAffinities(
+export function computeMaskedAffinities(
   qk: GTensor<'batch' | 'keyPos' | 'heads' | 'queryPos'>, // q @ k / rawAttention
 ): GTensor<'batch' | 'heads' | 'keyPos' | 'queryPos'> {
-  let upperInfTriangularMask = qk.TriangularMask('keyPos', 'queryPos', -Infinity);
+  let upperInfTriangularMask = qk.triangularMask('keyPos', 'queryPos', -Infinity);
   return qk.pointwiseAdd(upperInfTriangularMask);
 }
 
@@ -358,11 +358,8 @@ export function computeAttnHead(
       .scalarDiv(makeScalar(Math.sqrt(seqInput.dim.inputRep.size), 'float32'));
   }
 
-  const maskedAffinities = ComputeMaskedAffinities(rawAttention); // Uncomment this and the next lines to compute Masked Attention
-  const attention = maskedAffinities.softmax('queryPos'); // Uncomment this and the previous lines to compute Masked Attention
-  //const attention = rawAttention.softmax('queryPos'); // Uncomment this line to compute Unmasked self attention
-
-  // Dropout on the attention weights.
+  const maskedAffinities = computeMaskedAffinities(rawAttention);
+  const attention = maskedAffinities.softmax('queryPos');
   const attentionAfterDropout = dropout(spec.dropoutRate, attention, generator.random());
 
   const attendedValues = values

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -549,6 +549,21 @@ export function AllPastTokensLogits(
   return logits;
 }
 
+/**
+ * Returns the Softmax Cross Entropy Loss between the logits and the oneHotEncoded targets
+ * Batch compute the loss for all the past tokens of a transformer.
+ */
+export function AllPastTokensCrossEntropyLoss(
+  model: {
+    params: { tokenEmbedding: GTensor<'tokenId' | 'inputRep'> };
+  },
+  computation: TransformerComputation,
+  oneHotToken: GTensor<'batch'| 'pos'| 'tokenId'>
+): tf.Scalar {
+  const logits = AllPastTokensLogits(model, computation);
+  const crossEntropyLoss = tf.losses.softmaxCrossEntropy(oneHotToken.tensor,logits.tensor);
+  return crossEntropyLoss.asScalar()
+}
 /** Batch compute the top prediction from the last token of a transformer.
  *
  * params: transformer parameters.

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -319,8 +319,8 @@ function gelu(x: tf.Tensor) {
 export function ComputeMaskedAffinities(
   qk: GTensor<'batch' | 'keyPos' | 'heads' | 'queryPos'>, // q @ k / rawAttention
 ): GTensor<'batch' | 'heads' | 'keyPos' | 'queryPos'> {
-  let upperInfTriangularMask = qk.TriangularMask(['batch', 'keyPos', 'queryPos'], -Infinity)
-  return qk.pointwiseAdd(upperInfTriangularMask)
+  let upperInfTriangularMask = qk.TriangularMask('keyPos', 'queryPos', -Infinity);
+  return qk.pointwiseAdd(upperInfTriangularMask);
 }
 
 // (Approximation for) Compute (batched) attention.

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -560,8 +560,8 @@ export function allPastTokensCrossEntropyLoss(
   oneHotToken: GTensor<'batch' | 'pos' | 'tokenId'>,
 ): tf.Scalar {
   const logits = allPastTokensLogits(model, computation);
-  const crossEntropyLoss = tf.losses.softmaxCrossEntropy(oneHotToken.tensor, logits.tensor);
-  return crossEntropyLoss.asScalar();
+  const crossEntropyLoss = logits.softmaxCrossEntropy(oneHotToken);
+  return crossEntropyLoss.tensor.asScalar();
 }
 /** Batch compute the top prediction from the last token of a transformer.
  *

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -316,12 +316,6 @@ function gelu(x: tf.Tensor) {
   return tf.mul(x, cdf);
 }
 
-export function computeMaskedAffinities(
-  qk: GTensor<'batch' | 'keyPos' | 'heads' | 'queryPos'>, // q @ k / rawAttention
-): GTensor<'batch' | 'heads' | 'keyPos' | 'queryPos'> {
-  return qk.triangularMask('keyPos', 'queryPos', -Infinity);
-}
-
 // (Approximation for) Compute (batched) attention.
 //
 // Note: for non-batched attention, the code is identical, just remove the
@@ -360,7 +354,7 @@ export function computeAttnHead(
   // TODO: eventually we would like to pass in precomputed attention mask to the function,
   // rather than recompute attention masks inference pass
 
-  const maskedAffinities = computeMaskedAffinities(rawAttention);
+  const maskedAffinities = rawAttention.triangularMask('keyPos', 'queryPos', -Infinity);
   const attention = maskedAffinities.softmax('queryPos');
   const attentionAfterDropout = dropout(spec.dropoutRate, attention, generator.random());
 

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -535,6 +535,20 @@ export function lastTokenCrossEntropyLoss(
   // return loss.tensor;
 }
 
+/**
+ * Compute the logits for all the past tokens of a transformer
+ */
+export function AllPastTokensLogits(
+  model: {
+    params: { tokenEmbedding: GTensor<'tokenId' | 'inputRep'> };
+  },
+  computation: TransformerComputation
+): GTensor<'batch' | 'pos' | 'tokenId'> {
+  const lastLayer = computation.layers[computation.layers.length - 1];
+  const logits = lastLayer.seqOuput.contract(model.params.tokenEmbedding, ['inputRep']);
+  return logits;
+}
+
 /** Batch compute the top prediction from the last token of a transformer.
  *
  * params: transformer parameters.

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -358,6 +358,9 @@ export function computeAttnHead(
       .scalarDiv(makeScalar(Math.sqrt(seqInput.dim.inputRep.size), 'float32'));
   }
 
+  // TODO: eventually we would like to pass in precomputed attention mask to the function,
+  // rather than recompute attention masks inference pass
+
   const maskedAffinities = computeMaskedAffinities(rawAttention);
   const attention = maskedAffinities.softmax('queryPos');
   const attentionAfterDropout = dropout(spec.dropoutRate, attention, generator.random());
@@ -535,7 +538,7 @@ export function lastTokenCrossEntropyLoss(
 /**
  * Compute the logits for all the past tokens of a transformer
  */
-export function AllPastTokensLogits(
+export function allPastTokensLogits(
   model: {
     params: { tokenEmbedding: GTensor<'tokenId' | 'inputRep'> };
   },
@@ -550,14 +553,14 @@ export function AllPastTokensLogits(
  * Returns the Softmax Cross Entropy Loss between the logits and the oneHotEncoded targets
  * Batch compute the loss for all the past tokens of a transformer.
  */
-export function AllPastTokensCrossEntropyLoss(
+export function allPastTokensCrossEntropyLoss(
   model: {
     params: { tokenEmbedding: GTensor<'tokenId' | 'inputRep'> };
   },
   computation: TransformerComputation,
   oneHotToken: GTensor<'batch'| 'pos'| 'tokenId'>
 ): tf.Scalar {
-  const logits = AllPastTokensLogits(model, computation);
+  const logits = allPastTokensLogits(model, computation);
   const crossEntropyLoss = tf.losses.softmaxCrossEntropy(oneHotToken.tensor,logits.tensor);
   return crossEntropyLoss.asScalar()
 }

--- a/animated-transformer/src/lib/transformer/transformer_gtensor.ts
+++ b/animated-transformer/src/lib/transformer/transformer_gtensor.ts
@@ -316,6 +316,13 @@ function gelu(x: tf.Tensor) {
   return tf.mul(x, cdf);
 }
 
+export function ComputeMaskedAffinities(
+  qk: GTensor<'batch' | 'keyPos' | 'heads' | 'queryPos'>, // q @ k / rawAttention
+): GTensor<'batch' | 'heads' | 'keyPos' | 'queryPos'> {
+  let upperInfTriangularMask = qk.TriangularMask(['batch', 'keyPos', 'queryPos'], -Infinity)
+  return qk.pointwiseAdd(upperInfTriangularMask)
+}
+
 // (Approximation for) Compute (batched) attention.
 //
 // Note: for non-batched attention, the code is identical, just remove the


### PR DESCRIPTION
The changes in this pull request are organized in two parts: **Masked Self Attention** and **computing loss for all tokens at once** 

The first 3 commits add masked self attention, including:

- TriangularMask function to the GTensor class which computes a triangular mask of the same shape as the provided GTensor
- ComputeMaskedAffinities function to compute masked version of the previous rawAttention (transformer_gtensor.ts) with the help of the triangularMask
- Computing affinities and replacing previous attention to be computed over the masked affinities instead of rawAttention.

The following 5 commits add capability to compute the loss over all tokens at once:
- AllPastTokensLogits function to extract the tokens for all past positions in the last layer of the transformer
- NextTokenPerPosIdxOutputPrepFn function to generate an expected target token sequence for a given inputSequence by shifting the inputSeq to the right. This sequence will be used to compute the loss with respect to the logits.
- Calculating the cross Entropy Loss for all tokens simultaneously using tf.SoftmaxCrossEntropyLoss (at AllPastTokensCrossEntropyLoss)

I also Created an alternative version of tiny_worlds_train.script.ts (tiny_worlds_train_self_att.script.ts) to test the modifications. 

