### PR TITLE
Adds GTensor.where function to gtensor and unit tests.

### DIFF
--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -905,4 +905,109 @@ describe('gtensor', () => {
       [0, 0, 0],
     ]);
   });
+
+  it('where', async () => {
+    const g1 = new gtensor.GTensor(
+      tf.tensor(
+        [
+          [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+        ],
+      ),
+      ['example', 'pos', 'repSize'],
+    );
+
+    const g2 = new gtensor.GTensor(
+      tf.tensor(
+        [
+          [0, 0],
+          [0, 0],
+          [0, 0],
+        ],
+      ),
+      ['pos', 'repSize'],
+    );
+
+    const condition = tf.tensor([1, 0, 0, 1, 1, 0], [3, 2], 'bool');
+
+    const g1WhereCondition = g1.where(condition, g2);
+
+    expect(g1WhereCondition.dimNames).toEqual(['example', 'pos', 'repSize']);
+    tf.test_util.expectArraysEqual(g1WhereCondition.tensor.arraySync(), [
+      [
+        [1, 0],
+        [0, 4],
+        [5, 0],
+      ], // example = 1
+      [
+        [1, 0],
+        [0, 4],
+        [5, 0],
+      ],
+    ]);
+  });
+
+  it('where no broadcast over g2', async () => {
+    const g1 = new gtensor.GTensor(
+      tf.tensor(
+        [
+          [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+        ],
+      ),
+      ['example', 'pos', 'repSize'],
+    );
+
+    const g2 = new gtensor.GTensor(
+      tf.tensor(
+        [
+          [
+            [0, 0],
+            [0, 0],
+            [0, 0],
+          ], // example = 1
+          [
+            [0, 0],
+            [0, 0],
+            [0, 0],
+          ],
+        ], // example = 2
+      ),
+      ['example', 'pos', 'repSize'],
+    );
+
+    const condition = tf.tensor([1, 0, 0, 1, 1, 0], [3, 2], 'bool');
+
+    const g1WhereCondition = g1.where(condition, g2);
+
+    expect(g1WhereCondition.dimNames).toEqual(['example', 'pos', 'repSize']);
+    tf.test_util.expectArraysEqual(g1WhereCondition.tensor.arraySync(), [
+      [
+        [1, 0],
+        [0, 4],
+        [5, 0],
+      ], // example = 1
+      [
+        [1, 0],
+        [0, 4],
+        [5, 0],
+      ],
+    ]);
+  });
 });


### PR DESCRIPTION
Added GTensor.where function to gtensor library and unit tests. 
As in tf.where function, it returns the elements either of the gtensor or g2 depending on the condition provided.
If the condition is true, it selects the element from the gtensor, otherwise selects from g2.
If the dimensions of the gtensor are different from those of g2, substracted dimensions are broadcasted.