### PR TITLE
Add support for cross-entropy loss with integer labels

### DIFF
--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -712,31 +712,35 @@ describe('gtensor', () => {
     // Making a GTensor from a tensor by naming the dimensions:
     const g = new gtensor.GTensor(
       tf.tensor([
-        [1, 2, 3, 4],
-        [5, 6, 7, 8],
+        [[1, 2, 3, 4],
+        [5, 6, 7, 8]],
+        [[9, 10, 11, 12],
+        [13, 14, 15, 16]],
       ]),
-      ['batch', 'logits'],
+      ['batch', 'pos', 'logits'],
     );
 
     const indexes = new gtensor.GTensor(
       tf.tensor(
         [
-          0, 1
+          [0, 1],
+          [2, 3],
         ],
-        [2],
+        [2, 2],
         'int32',
       ),
-      ['batch'],
+      ['batch', 'pos'],
     );
 
-    const gathered = g.gather(indexes, 'logits', ['batch']);
+    const gathered = g.gather(indexes, 'logits', ['batch', 'pos']);
 
-    expect(gathered.dimNames).toEqual(['batch']);
+    expect(gathered.dimNames).toEqual(['batch', 'pos']);
     tf.test_util.expectArraysClose(
       gathered.tensor.dataSync(),
       tf
         .tensor([
-          1, 6
+          [1, 6],
+          [11, 16],
         ])
         .dataSync(),
     );

--- a/animated-transformer/src/lib/gtensor/gtensor.spec.ts
+++ b/animated-transformer/src/lib/gtensor/gtensor.spec.ts
@@ -19,7 +19,7 @@ import { DName, Dims, GTensor, gtensorOfDims } from './gtensor';
 import * as tf from '@tensorflow/tfjs';
 
 describe('gtensor', () => {
-  beforeEach(() => {});
+  beforeEach(() => { });
 
   it('creatingGTensors', () => {
     // Making a GTensor with an initializer:
@@ -708,6 +708,40 @@ describe('gtensor', () => {
     );
   });
 
+  it('gather with batch dimensions', () => {
+    // Making a GTensor from a tensor by naming the dimensions:
+    const g = new gtensor.GTensor(
+      tf.tensor([
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ]),
+      ['batch', 'logits'],
+    );
+
+    const indexes = new gtensor.GTensor(
+      tf.tensor(
+        [
+          0, 1
+        ],
+        [2],
+        'int32',
+      ),
+      ['batch'],
+    );
+
+    const gathered = g.gather(indexes, 'logits', ['batch']);
+
+    expect(gathered.dimNames).toEqual(['batch']);
+    tf.test_util.expectArraysClose(
+      gathered.tensor.dataSync(),
+      tf
+        .tensor([
+          1, 6
+        ])
+        .dataSync(),
+    );
+  });
+
   it('variable assign', () => {
     // Making a GTensor from a tensor by naming the dimensions:
     const x = new gtensor.GTensor(tf.tensor([1, 2, 3, 4]), ['foo']);
@@ -786,6 +820,39 @@ describe('gtensor', () => {
     tf.test_util.expectArraysClose(
       gsoftmax.tensor.dataSync(),
       expectedGTensor.transposeLike(gsoftmax).tensor.dataSync(),
+    );
+  });
+
+  it('softmax cross entropy with integer labels', () => {
+    const g = new gtensor.GTensor(
+      tf.tensor([
+        [
+          1.2, -0.8, -0.5,
+        ],
+        [
+          0.9, -1.2, 1.1,
+        ],
+      ], [2, 3]),
+      ['batch', 'logits'],
+    );
+
+    const labels = new gtensor.GTensor(
+      tf.tensor([
+        0, 1
+      ], [2], 'int32'),
+      ['batch'],
+    )
+
+    const loss = g.softmaxCrossEntropyWithIntegerLabels(labels, 'logits');
+
+    expect(loss.dimNames).toEqual(['batch']);
+    tf.test_util.expectArraysClose(
+      loss.tensor.dataSync(),
+      tf
+        .tensor([
+          0.27612971, 2.9517988
+        ])
+        .dataSync(),
     );
   });
 
@@ -873,8 +940,8 @@ describe('gtensor', () => {
 
     type ExactGTensor<Exact extends string, Given extends string> =
       Exclude<Given, Exact> extends never
-        ? GTensor<Given>
-        : ErrorGivenHadExtraTypes<Exclude<Given, Exact>>;
+      ? GTensor<Given>
+      : ErrorGivenHadExtraTypes<Exclude<Given, Exact>>;
 
     function attentionHeadFn2<T extends string>(
       maybeInput: ExactGTensor<'seqLen' | 'inputRep', T>,

--- a/animated-transformer/src/lib/tokens/token_gemb.spec.ts
+++ b/animated-transformer/src/lib/tokens/token_gemb.spec.ts
@@ -37,7 +37,7 @@ describe('token_gemb', () => {
     const tokens = ['a', 'b', '[pad]'];
     const tokenRep = prepareBasicTaskTokenRep(tokens);
     const embeddings = new GTensor(tf.tensor([aEmb, bEmb, padEmb]), ['tokenId', 'inputRep']);
-    const seqToEmbed = ['a', 'b', '[PAD]', 'a'];
+    const seqToEmbed = ['a', 'b', '[pad]', 'a'];
     const embeddedSeq = embed(tokenRep.tokenToIdx, embeddings, seqToEmbed);
     const positionEmb = embeddedSeq.unstack('pos');
     expect(positionEmb.length).toEqual(4);
@@ -144,25 +144,23 @@ describe('token_gemb', () => {
       ['b', 'a'],
     ];
     const batchOutput: string[][] = [['a'], ['b']];
-    const targetTokensOneHot = expectedOutputSeqPrepFn(
+    const targetTokens = expectedOutputSeqPrepFn(
       { config: { tokenRep } },
       batchInput,
       batchOutput,
     );
 
-    const expectedOutputArr: number[][][] = [
+    const expectedOutputArr: number[][] = [
       [
-        [0, 1, 0, 0, 0, 0],
-        [1, 0, 0, 0, 0, 0],
+        1, 0
       ],
       [
-        [1, 0, 0, 0, 0, 0],
-        [0, 1, 0, 0, 0, 0],
+        0, 1
       ],
     ];
 
-    expect(targetTokensOneHot.tensor.arraySync()).toEqual(expectedOutputArr);
-    expect(targetTokensOneHot.dimNames).toEqual(['batch', 'pos', 'tokenId'])
+    expect(targetTokens.tensor.arraySync()).toEqual(expectedOutputArr);
+    expect(targetTokens.dimNames).toEqual(['batch', 'pos'])
   });
   it('Test tokenizeAndMapToIdx', () => {
     // Mock a tokenizer for testing tokenizeAndMapToIdx.

--- a/animated-transformer/src/lib/transformer/common_transformer.ts
+++ b/animated-transformer/src/lib/transformer/common_transformer.ts
@@ -153,6 +153,21 @@ export function allPastTokensCrossEntropyLoss(
     return crossEntropyLoss.tensor.asScalar();
 }
 
+/**
+ * Returns Softmax Cross Entropy Loss with integer labels instead of requiring one hot encoded targets.
+ */
+export function allPastTokensCrossEntropyLossWithIntegerLabels(
+    model: {
+        params: { tokenEmbedding: GTensor<'tokenId' | 'inputRep'> };
+    },
+    computation: TransformerComputation,
+    labels: GTensor<'batch' | 'pos'>,
+): tf.Scalar {
+    const logits = allPastTokensLogits(model, computation);
+    const crossEntropyLoss = logits.softmaxCrossEntropyWithIntegerLabels(labels, 'tokenId');
+    return crossEntropyLoss.tensor.asScalar();
+}
+
 export function computeMaxInputLength(
     posEncodingSeqLength: number,
     inputs: string[][] | number[][]


### PR DESCRIPTION
Adds support for cross-entropy loss with integer labels (Issue #60) following Jax implementation in `softmax_cross_entropy_with_integer_labels` in the Optax library.

* Additionaly we clean-up one-hot encodings from task definition.
* We fix the training script so that it works with new loss.