### PR TITLE
refactor: clean up deprecated Angular animations and setup types

### DIFF
--- a/animated-transformer/src/app/activation-vis/activation-vis.component.spec.ts
+++ b/animated-transformer/src/app/activation-vis/activation-vis.component.spec.ts
@@ -16,7 +16,6 @@ limitations under the License.
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ActivationVisComponent } from './activation-vis.component';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CornerActivationComponent } from './corner-activation/corner-activation.component';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideMarkdown, KATEX_OPTIONS, MarkedKatexOptions } from 'ngx-markdown';
@@ -39,7 +38,7 @@ describe('ActivationVisComponent', () => {
           } as MarkedKatexOptions & { nonStandard?: boolean }
         }
       ],
-      imports: [NoopAnimationsModule, ActivationVisComponent, CornerActivationComponent],
+      imports: [ActivationVisComponent, CornerActivationComponent],
     }).compileComponents();
   });
 

--- a/animated-transformer/src/app/activation-vis/activation-vis.component.ts
+++ b/animated-transformer/src/app/activation-vis/activation-vis.component.ts
@@ -47,7 +47,7 @@ import { AutoCompletedTextInputComponent } from '../auto-completed-text-input/au
 import { ActivationManagerComponent } from './activation-manager/activation-manager.component';
 import { NanValidatorDirective } from '../form-validators/nan-validator.directive';
 import { BoundedFloatValidatorDirective } from '../form-validators/bounded-float-validator.directive';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownComponent } from 'ngx-markdown';
 
 interface DatasetExample {
   input: number[];
@@ -77,7 +77,7 @@ interface DatasetExample {
     // ActivationManagerDirective,
     // NanValidatorDirective,
     // BoundedFloatValidatorDirective,
-    MarkdownModule,
+    MarkdownComponent,
   ],
   templateUrl: './activation-vis.component.html',
   styleUrls: ['./activation-vis.component.scss'],

--- a/animated-transformer/src/app/activation-vis/corner-activation/corner-activation.component.spec.ts
+++ b/animated-transformer/src/app/activation-vis/corner-activation/corner-activation.component.spec.ts
@@ -37,7 +37,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MonacoConfigEditorComponent } from 'src/app/monaco-config-editor/monaco-config-editor.component';
 import { TensorImageComponent } from 'src/app/tensor-image/tensor-image.component';
 import { MatInputModule } from '@angular/material/input';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 describe('CornerActivationComponent', () => {
   let component: CornerActivationComponent;
@@ -45,7 +44,7 @@ describe('CornerActivationComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
+      providers: [provideZonelessChangeDetection()],
       imports: [
         CommonModule,
         FormsModule,

--- a/animated-transformer/src/app/animated-transformer/animated-transformer.component.spec.ts
+++ b/animated-transformer/src/app/animated-transformer/animated-transformer.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AnimatedTransformerComponent } from './animated-transformer.component';
 import { TinyModelsService } from '../tiny-models.service';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { provideZonelessChangeDetection } from '@angular/core';
 
@@ -15,7 +14,6 @@ describe('AnimatedTransformerComponent', () => {
       providers: [
         provideZonelessChangeDetection(),
         TinyModelsService,
-        provideNoopAnimations(),
         provideRouter([]),
       ],
       imports: [AnimatedTransformerComponent],

--- a/animated-transformer/src/app/animated-transformer/model-task-trainer/model-task-trainer.component.spec.ts
+++ b/animated-transformer/src/app/animated-transformer/model-task-trainer/model-task-trainer.component.spec.ts
@@ -17,7 +17,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ModelTaskTrainerComponent } from './model-task-trainer.component';
 import { provideRouter } from '@angular/router';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideZonelessChangeDetection } from '@angular/core';
 
 describe('ModelTaskTrainerComponent', () => {
@@ -29,7 +28,6 @@ describe('ModelTaskTrainerComponent', () => {
       providers: [
         provideZonelessChangeDetection(),
         provideRouter([]),
-        provideNoopAnimations(),
       ],
       imports: [ModelTaskTrainerComponent],
       declarations: [],

--- a/animated-transformer/src/app/app.component.spec.ts
+++ b/animated-transformer/src/app/app.component.spec.ts
@@ -18,7 +18,6 @@ import { AppComponent } from './app.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideRouter, withComponentInputBinding, withHashLocation } from '@angular/router';
 import { routes } from './app.config';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideZonelessChangeDetection } from '@angular/core';
 
 describe('AppComponent', () => {
@@ -28,7 +27,7 @@ describe('AppComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter(routes, withComponentInputBinding(), withHashLocation()),
       ],
-      imports: [NoopAnimationsModule, AppComponent],
+      imports: [AppComponent],
       declarations: [],
     }).compileComponents();
   });

--- a/animated-transformer/src/app/app.config.ts
+++ b/animated-transformer/src/app/app.config.ts
@@ -15,7 +15,6 @@ limitations under the License.
 import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
 
 import { provideMarkdown, KATEX_OPTIONS, MarkedKatexOptions } from 'ngx-markdown';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 import { provideRouter, Routes, withComponentInputBinding, withHashLocation } from '@angular/router';
 
@@ -81,7 +80,6 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
     provideRouter(routes, withComponentInputBinding(), withHashLocation()),
-    provideAnimationsAsync(),
     provideMarkdown(),
     {
       provide: KATEX_OPTIONS,
@@ -98,7 +96,7 @@ export const appConfig: ApplicationConfig = {
 // export const testConfig: ApplicationConfig = {
 //   providers: [
 //     provideRouter(routes, withComponentInputBinding()),
-//     provideNoopAnimations(),
+//     provideAnimationsAsync('noop'),
 //     provideMarkdown(),
 //   ],
 // };

--- a/animated-transformer/src/app/auto-completed-text-input/auto-completed-text-input.component.spec.ts
+++ b/animated-transformer/src/app/auto-completed-text-input/auto-completed-text-input.component.spec.ts
@@ -20,7 +20,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideZonelessChangeDetection } from '@angular/core';
 
 describe('AutoCompletedTextInputComponent', () => {
@@ -30,7 +29,7 @@ describe('AutoCompletedTextInputComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       providers: [provideZonelessChangeDetection()],
-      imports: [NoopAnimationsModule, AutoCompletedTextInputComponent],
+      imports: [AutoCompletedTextInputComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AutoCompletedTextInputComponent);

--- a/animated-transformer/src/app/berkovich-vis/berkovich-vis.component.ts
+++ b/animated-transformer/src/app/berkovich-vis/berkovich-vis.component.ts
@@ -18,7 +18,7 @@ import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { RouterModule } from '@angular/router';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownComponent } from 'ngx-markdown';
 import katex from 'katex';
 // @ts-ignore
 import renderMathInElement from 'katex/dist/contrib/auto-render.js';
@@ -58,7 +58,7 @@ import { BerkovichHistoryComponent } from './history-card/berkovich-history.comp
     MatIconModule,
     MatButtonModule,
     RouterModule,
-    MarkdownModule,
+    MarkdownComponent,
     BerkovichTreeVisComponent,
     BerkovichConfigComponent,
     BerkovichStateComponent,

--- a/animated-transformer/src/app/berkovich-vis/calculus-card/berkovich-calculus.component.ts
+++ b/animated-transformer/src/app/berkovich-vis/calculus-card/berkovich-calculus.component.ts
@@ -17,7 +17,7 @@ import { Component, input, signal, ChangeDetectionStrategy } from '@angular/core
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownComponent } from 'ngx-markdown';
 import { Rational, simplify } from '../../../lib/berkovich/berkovich';
 
 @Component({
@@ -28,7 +28,7 @@ import { Rational, simplify } from '../../../lib/berkovich/berkovich';
     CommonModule,
     MatCardModule,
     MatIconModule,
-    MarkdownModule
+    MarkdownComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/animated-transformer/src/app/berkovich-vis/digits-card/berkovich-digits.component.ts
+++ b/animated-transformer/src/app/berkovich-vis/digits-card/berkovich-digits.component.ts
@@ -17,7 +17,7 @@ import { Component, input, signal, ChangeDetectionStrategy } from '@angular/core
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownComponent } from 'ngx-markdown';
 
 export interface DigitRowColumn {
   power: number;
@@ -36,7 +36,7 @@ export interface DigitRowColumn {
     CommonModule,
     MatCardModule,
     MatIconModule,
-    MarkdownModule
+    MarkdownComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/animated-transformer/src/app/berkovich-vis/history-card/berkovich-history.component.ts
+++ b/animated-transformer/src/app/berkovich-vis/history-card/berkovich-history.component.ts
@@ -17,7 +17,7 @@ import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownComponent } from 'ngx-markdown';
 import { Rational, simplify } from '../../../lib/berkovich/berkovich';
 
 export interface HistoryItem {
@@ -36,7 +36,7 @@ export interface HistoryItem {
     CommonModule,
     MatCardModule,
     MatIconModule,
-    MarkdownModule
+    MarkdownComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/animated-transformer/src/app/berkovich-vis/state-card/berkovich-state.component.ts
+++ b/animated-transformer/src/app/berkovich-vis/state-card/berkovich-state.component.ts
@@ -17,7 +17,7 @@ import { Component, input, computed, ChangeDetectionStrategy } from '@angular/co
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownComponent } from 'ngx-markdown';
 import { Rational, simplify } from '../../../lib/berkovich/berkovich';
 
 @Component({
@@ -28,7 +28,7 @@ import { Rational, simplify } from '../../../lib/berkovich/berkovich';
     CommonModule,
     MatCardModule,
     MatIconModule,
-    MarkdownModule
+    MarkdownComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/animated-transformer/src/app/berkovich-vis/tree-vis/berkovich-tree-vis.component.ts
+++ b/animated-transformer/src/app/berkovich-vis/tree-vis/berkovich-tree-vis.component.ts
@@ -17,7 +17,7 @@ import { Component, input, output, computed, signal, effect, untracked, ChangeDe
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownComponent } from 'ngx-markdown';
 import katex from 'katex';
 // @ts-ignore
 import renderMathInElement from 'katex/dist/contrib/auto-render.js';
@@ -68,7 +68,7 @@ export interface VisualEdge {
     CommonModule,
     MatCardModule,
     MatIconModule,
-    MarkdownModule
+    MarkdownComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/animated-transformer/src/app/landing-page/landing-page.component.spec.ts
+++ b/animated-transformer/src/app/landing-page/landing-page.component.spec.ts
@@ -18,7 +18,6 @@ import { LandingPageComponent } from './landing-page.component';
 import { provideRouter } from '@angular/router';
 import { routes } from '../app.config';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LandingPageComponent', () => {
   beforeEach(async () => {
@@ -27,7 +26,7 @@ describe('LandingPageComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter(routes),
       ],
-      imports: [NoopAnimationsModule, LandingPageComponent],
+      imports: [LandingPageComponent],
     }).compileComponents();
   });
 

--- a/animated-transformer/src/app/logic-explorer/logic-advanced-docs.component.spec.ts
+++ b/animated-transformer/src/app/logic-explorer/logic-advanced-docs.component.spec.ts
@@ -17,7 +17,6 @@ import { LogicAdvancedDocsComponent } from './logic-advanced-docs.component';
 import { provideRouter } from '@angular/router';
 import { routes } from '../app.config';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LogicAdvancedDocsComponent', () => {
   beforeEach(async () => {
@@ -26,7 +25,7 @@ describe('LogicAdvancedDocsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter(routes),
       ],
-      imports: [NoopAnimationsModule, LogicAdvancedDocsComponent],
+      imports: [LogicAdvancedDocsComponent],
     }).compileComponents();
   });
 

--- a/animated-transformer/src/app/logic-explorer/logic-docs.component.spec.ts
+++ b/animated-transformer/src/app/logic-explorer/logic-docs.component.spec.ts
@@ -17,7 +17,6 @@ import { LogicDocsComponent } from './logic-docs.component';
 import { provideRouter } from '@angular/router';
 import { routes } from '../app.config';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LogicDocsComponent', () => {
   beforeEach(async () => {
@@ -26,7 +25,7 @@ describe('LogicDocsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter(routes),
       ],
-      imports: [NoopAnimationsModule, LogicDocsComponent],
+      imports: [LogicDocsComponent],
     }).compileComponents();
   });
 

--- a/animated-transformer/src/app/logic-explorer/logic-explorer.component.spec.ts
+++ b/animated-transformer/src/app/logic-explorer/logic-explorer.component.spec.ts
@@ -9,7 +9,6 @@ import { LogicExplorerComponent } from './logic-explorer.component';
 import { provideRouter } from '@angular/router';
 import { routes } from '../app.config';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { vi } from 'vitest';
 
 describe('LogicExplorerComponent', () => {
@@ -19,7 +18,7 @@ describe('LogicExplorerComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter(routes),
       ],
-      imports: [NoopAnimationsModule, LogicExplorerComponent],
+      imports: [LogicExplorerComponent],
     }).compileComponents();
   });
 

--- a/animated-transformer/src/app/logic-explorer/logic-sim-docs.component.spec.ts
+++ b/animated-transformer/src/app/logic-explorer/logic-sim-docs.component.spec.ts
@@ -17,7 +17,6 @@ import { LogicSimDocsComponent } from './logic-sim-docs.component';
 import { provideRouter } from '@angular/router';
 import { routes } from '../app.config';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LogicSimDocsComponent', () => {
   beforeEach(async () => {
@@ -26,7 +25,7 @@ describe('LogicSimDocsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter(routes),
       ],
-      imports: [NoopAnimationsModule, LogicSimDocsComponent],
+      imports: [LogicSimDocsComponent],
     }).compileComponents();
   });
 

--- a/animated-transformer/src/app/web-colab/placeholder/placeholder.component.spec.ts
+++ b/animated-transformer/src/app/web-colab/placeholder/placeholder.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PlaceholderComponent } from './placeholder.component';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SignalSpace } from 'src/lib/signalspace/signalspace';
 import { LabEnv } from 'src/lib/distr-signals/lab-env';
 import { SecDefKind, SecDefOfPlaceholder, SecDefOfSecList } from 'src/lib/weblab/section';
@@ -41,7 +40,7 @@ describe('PlaceholderComponent', () => {
     const section = [...experiment.sectionMap.values()][0];
 
     await TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
+      providers: [provideZonelessChangeDetection()],
       imports: [PlaceholderComponent],
     }).compileComponents();
 

--- a/animated-transformer/src/app/web-colab/section/section.component.spec.ts
+++ b/animated-transformer/src/app/web-colab/section/section.component.spec.ts
@@ -18,7 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SectionComponent } from './section.component';
 import { LabEnv } from 'src/lib/distr-signals/lab-env';
 import { SignalSpace } from 'src/lib/signalspace/signalspace';
-import { MarkdownModule } from 'ngx-markdown';
+import { provideMarkdown } from 'ngx-markdown';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { makeToyExperiment } from 'src/weblab-examples/toy-experiment';
 import { provideHttpClient } from '@angular/common/http';
@@ -33,8 +33,12 @@ describe('SectionComponent', () => {
     const exp = await makeToyExperiment(env, 'toy experiment id');
 
     await TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection(), provideHttpClient()],
-      imports: [MarkdownModule.forRoot(), SectionComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideMarkdown()
+      ],
+      imports: [SectionComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SectionComponent);

--- a/animated-transformer/src/app/web-colab/section/section.component.ts
+++ b/animated-transformer/src/app/web-colab/section/section.component.ts
@@ -23,7 +23,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import { Experiment } from '../../../lib/weblab/experiment';
-import { MarkdownModule, MarkdownService } from 'ngx-markdown';
+import { MarkdownComponent, MarkdownService } from 'ngx-markdown';
 import {
   MonacoConfigEditorComponent,
   ConfigUpdate,
@@ -69,7 +69,7 @@ export enum DisplayKind {
 @Component({
   selector: 'app-section',
   imports: [
-    MarkdownModule,
+    MarkdownComponent,
     MatButtonModule,
     MatMenuModule,
     MatIconModule,

--- a/animated-transformer/tsconfig.json
+++ b/animated-transformer/tsconfig.json
@@ -23,6 +23,14 @@
     "useDefineForClassFields": false,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "types": [
+      // Required so the editor language service can resolve Vitest test globals 
+      // (e.g. describe, it, expect) in spec files.
+      "vitest/globals",
+      // Typings for the File System Access API (FileSystemDirectoryHandle) used 
+      // by BrowserDirDataResolver in src/lib/data-resolver/data-resolver.ts.
+      "wicg-file-system-access"
+    ],
     "lib": [
       "ESNext",
       "dom"


### PR DESCRIPTION
This PR resolves TypeScript editor errors for Vitest globals and cleans up deprecated animation providers across the application config and unit tests.